### PR TITLE
Fixup of initial jt-264-basics merge PR #282

### DIFF
--- a/basics/ant/pom.xml
+++ b/basics/ant/pom.xml
@@ -2,10 +2,10 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jaxb2-basics-ant</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Ant Task</name>
+	<name>JAXB Tools :: JAXB Basics :: Ant Task</name>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
-		<artifactId>jaxb2-basics-project</artifactId>
+		<groupId>org.jvnet.jaxb</groupId>
+		<artifactId>jaxb-basics-project</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<dependencies>

--- a/basics/basic/pom.xml
+++ b/basics/basic/pom.xml
@@ -2,19 +2,19 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jaxb2-basics</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Basic Plugins</name>
+	<name>JAXB Tools :: JAXB Basics :: Basic Plugins</name>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
-		<artifactId>jaxb2-basics-project</artifactId>
+		<groupId>org.jvnet.jaxb</groupId>
+		<artifactId>jaxb-basics-project</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-tools</artifactId>
 		</dependency>
 		<dependency>
@@ -32,8 +32,8 @@
 			<artifactId>javaparser</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2.maven2</groupId>
-			<artifactId>maven-jaxb2-plugin-testing</artifactId>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-testing</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -78,13 +78,13 @@
 										<pluginExecution>
 											<pluginExecutionFilter>
 												<groupId>
-													org.jvnet.jaxb2.maven2
+													org.jvnet.jaxb
 												</groupId>
 												<artifactId>
-													maven-jaxb2-plugin
+													jaxb-maven-plugin
 												</artifactId>
 												<versionRange>
-													[0.8.1,)
+													[2.0.0,)
 												</versionRange>
 												<goals>
 													<goal>generate</goal>

--- a/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/copyable/tests/RunCopyablePlugin.java
+++ b/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/copyable/tests/RunCopyablePlugin.java
@@ -4,8 +4,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb2.maven2.AbstractXJC2Mojo;
-import org.jvnet.jaxb2.maven2.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
+import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
 
 public class RunCopyablePlugin extends RunXJC2Mojo {
 

--- a/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/equals/tests/RunEqualsPlugin.java
+++ b/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/equals/tests/RunEqualsPlugin.java
@@ -4,8 +4,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb2.maven2.AbstractXJC2Mojo;
-import org.jvnet.jaxb2.maven2.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
+import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
 
 public class RunEqualsPlugin extends RunXJC2Mojo {
 

--- a/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/mergeable/tests/RunMergeablePlugin.java
+++ b/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/mergeable/tests/RunMergeablePlugin.java
@@ -4,8 +4,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb2.maven2.AbstractXJC2Mojo;
-import org.jvnet.jaxb2.maven2.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
+import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
 
 public class RunMergeablePlugin extends RunXJC2Mojo {
 

--- a/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/tostring/tests/RunToStringPlugin.java
+++ b/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/tostring/tests/RunToStringPlugin.java
@@ -4,8 +4,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb2.maven2.AbstractXJC2Mojo;
-import org.jvnet.jaxb2.maven2.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
+import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
 import org.jvnet.jaxb2_commons.lang.JAXBToStringStrategy;
 
 public class RunToStringPlugin extends RunXJC2Mojo {

--- a/basics/dist/pom.xml
+++ b/basics/dist/pom.xml
@@ -2,13 +2,13 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.jvnet.jaxb2_commons</groupId>
+	<groupId>org.jvnet.jaxb</groupId>
 	<artifactId>jaxb2-basics-dist</artifactId>
 	<packaging>pom</packaging>
-	<name>JAXB2 Basics - Distribution</name>
+	<name>JAXB Tools :: JAXB Basics :: Distribution</name>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
-		<artifactId>jaxb2-basics-project</artifactId>
+		<groupId>org.jvnet.jaxb</groupId>
+		<artifactId>jaxb-basics-project</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<dependencies>

--- a/basics/plugins/pom.xml
+++ b/basics/plugins/pom.xml
@@ -2,23 +2,23 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jaxb2-basics-plugins</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Full Plugins JAR</name>
+	<name>JAXB Tools :: JAXB Basics :: Full Plugins JAR</name>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
-		<artifactId>jaxb2-basics-project</artifactId>
+		<groupId>org.jvnet.jaxb</groupId>
+		<artifactId>jaxb-basics-project</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-tools</artifactId>
 		</dependency>
 		<dependency>

--- a/basics/pom.xml
+++ b/basics/pom.xml
@@ -8,7 +8,7 @@
         </parent>
 	<artifactId>jaxb-basics-project</artifactId>
 	<packaging>pom</packaging>
-	<name>JAXB2 Basics - Project</name>
+	<name>JAXB Tools :: JAXB Basics :: Project</name>
 	<description>JAXB Basics is a part of JAXB Tools project which implements plugins and tools for JAXB implementation.</description>
 	<modules>
 		<module>ant</module>
@@ -65,32 +65,32 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>org.jvnet.jaxb2_commons</groupId>
+				<groupId>org.jvnet.jaxb</groupId>
 				<artifactId>jaxb2-basics-plugins</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jvnet.jaxb2_commons</groupId>
+				<groupId>org.jvnet.jaxb</groupId>
 				<artifactId>jaxb2-basics-ant</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jvnet.jaxb2_commons</groupId>
+				<groupId>org.jvnet.jaxb</groupId>
 				<artifactId>jaxb2-basics-runtime</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jvnet.jaxb2_commons</groupId>
+				<groupId>org.jvnet.jaxb</groupId>
 				<artifactId>jaxb2-basics-tools</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jvnet.jaxb2_commons</groupId>
+				<groupId>org.jvnet.jaxb</groupId>
 				<artifactId>jaxb2-basics-testing</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jvnet.jaxb2_commons</groupId>
+				<groupId>org.jvnet.jaxb</groupId>
 				<artifactId>jaxb2-basics</artifactId>
 				<version>${project.version}</version>
 			</dependency>

--- a/basics/runtime/pom.xml
+++ b/basics/runtime/pom.xml
@@ -2,10 +2,10 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jaxb2-basics-runtime</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Runtime</name>
+	<name>JAXB Tools :: JAXB Basics :: Runtime</name>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
-		<artifactId>jaxb2-basics-project</artifactId>
+		<groupId>org.jvnet.jaxb</groupId>
+		<artifactId>jaxb-basics-project</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<dependencies>

--- a/basics/runtime/src/test/java/org/jvnet/jaxb2_commons/lang/tests/DefaultCopyStrategyTest.java
+++ b/basics/runtime/src/test/java/org/jvnet/jaxb2_commons/lang/tests/DefaultCopyStrategyTest.java
@@ -1,0 +1,45 @@
+package org.jvnet.jaxb2_commons.lang.tests;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Polygon;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.jaxb2_commons.lang.DefaultCopyStrategy;
+import org.jvnet.jaxb2_commons.lang.tests.pojo.CloneableNoClone;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+public class DefaultCopyStrategyTest {
+
+    @Test
+    public void testPolygonOK() {
+        final GeometryFactory geometryFactory = new GeometryFactory();
+        final Polygon polygon = geometryFactory.createPolygon(
+                geometryFactory.createLinearRing(new Coordinate[] {
+                        new Coordinate(0, 0, 0), new Coordinate(1, 1, 0),
+
+                        new Coordinate(1, 0, 0), new Coordinate(0, 1, 0),
+                        new Coordinate(0, 0, 0) }), null);
+
+        polygon.clone();
+
+        new DefaultCopyStrategy().copy(null, polygon);
+    }
+
+    @Test
+    public void testXMLGregorianCalendarOK() throws DatatypeConfigurationException {
+        final XMLGregorianCalendar calendar = DatatypeFactory.newInstance().newXMLGregorianCalendar();
+
+        new DefaultCopyStrategy().copy(null, calendar);
+    }
+    @Test
+    public void testCloneableNoCloneKO() {
+        final CloneableNoClone object = new CloneableNoClone("no-clone-method-in-it");
+
+        Assert.assertThrows("Exception UnsupportedOperationException not thrown",
+                UnsupportedOperationException.class, () -> new DefaultCopyStrategy().copy(null, object));
+    }
+}

--- a/basics/runtime/src/test/java/org/jvnet/jaxb2_commons/lang/tests/pojo/CloneableNoClone.java
+++ b/basics/runtime/src/test/java/org/jvnet/jaxb2_commons/lang/tests/pojo/CloneableNoClone.java
@@ -1,0 +1,13 @@
+package org.jvnet.jaxb2_commons.lang.tests.pojo;
+
+public class CloneableNoClone implements Cloneable {
+    private final String attribute;
+
+    public CloneableNoClone(String attribute) {
+        this.attribute = attribute;
+    }
+
+    public String getAttribute() {
+        return attribute;
+    }
+}

--- a/basics/samples/basic/pom.xml
+++ b/basics/samples/basic/pom.xml
@@ -4,9 +4,9 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jaxb2-basics-sample-basic</artifactId>
 	<packaging>pom</packaging>
-	<name>JAXB2 Basics - Sample [basic]</name>
+	<name>JAXB Tools :: JAXB Basics :: Sample [basic]</name>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-samples</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
@@ -16,15 +16,15 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-plugins</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-testing</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-ant</artifactId>
 		</dependency>
 		<dependency>

--- a/basics/samples/basic/project-pom.xml
+++ b/basics/samples/basic/project-pom.xml
@@ -21,12 +21,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-testing</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
@@ -42,9 +42,9 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
-				<version>${maven-jaxb2-plugin.version}</version>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
+				<version>${project.version}</version>
 				<executions>
 					<execution>
 						<goals>
@@ -63,7 +63,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 							<version>${project.version}</version>
 						</plugin>

--- a/basics/samples/cxf/pom.xml
+++ b/basics/samples/cxf/pom.xml
@@ -4,9 +4,9 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jaxb2-basics-sample-cxf</artifactId>
 	<packaging>pom</packaging>
-	<name>JAXB2 Basics - Sample [cxf]</name>
+	<name>JAXB Tools :: JAXB Basics :: Sample [cxf]</name>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-samples</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
@@ -16,15 +16,15 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-plugins</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-testing</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-ant</artifactId>
 		</dependency>
 		<dependency>

--- a/basics/samples/cxf/project-pom.xml
+++ b/basics/samples/cxf/project-pom.xml
@@ -33,7 +33,7 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -98,7 +98,7 @@
 						<version>${jaxb-core.version}</version>
 					</dependency>
 					<dependency>
-						<groupId>org.jvnet.jaxb2_commons</groupId>
+						<groupId>org.jvnet.jaxb</groupId>
 						<artifactId>jaxb2-basics</artifactId>
 						<version>${project.version}</version>
 					</dependency>

--- a/basics/samples/po-simple/pom.xml
+++ b/basics/samples/po-simple/pom.xml
@@ -4,9 +4,9 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jaxb2-basics-sample-po-simple</artifactId>
 	<packaging>pom</packaging>
-	<name>JAXB2 Basics - Sample [po-simple]</name>
+	<name>JAXB Tools :: JAXB Basics :: Sample [po-simple]</name>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-samples</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
@@ -16,15 +16,15 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-plugins</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-testing</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-ant</artifactId>
 		</dependency>
 		<dependency>

--- a/basics/samples/po-simple/project-pom.xml
+++ b/basics/samples/po-simple/project-pom.xml
@@ -21,7 +21,7 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-testing</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
@@ -37,9 +37,9 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
-				<version>${maven-jaxb2-plugin.version}</version>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
+				<version>${project.version}</version>
 				<executions>
 					<execution>
 						<goals>
@@ -54,7 +54,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 							<version>${project.version}</version>
 						</plugin>

--- a/basics/samples/po/pom.xml
+++ b/basics/samples/po/pom.xml
@@ -4,9 +4,9 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jaxb2-basics-sample-po</artifactId>
 	<packaging>pom</packaging>
-	<name>JAXB2 Basics - Sample [po]</name>
+	<name>JAXB Tools :: JAXB Basics :: Sample [po]</name>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-samples</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
@@ -16,15 +16,15 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-plugins</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-testing</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-ant</artifactId>
 		</dependency>
 		<dependency>

--- a/basics/samples/po/project-pom.xml
+++ b/basics/samples/po/project-pom.xml
@@ -21,12 +21,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-testing</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
@@ -42,9 +42,9 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
-				<version>${maven-jaxb2-plugin.version}</version>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
+				<version>${project.version}</version>
 				<executions>
 					<execution>
 						<goals>
@@ -63,7 +63,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 							<version>${project.version}</version>
 						</plugin>

--- a/basics/samples/pom.xml
+++ b/basics/samples/pom.xml
@@ -4,10 +4,10 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jaxb2-basics-samples</artifactId>
 	<packaging>pom</packaging>
-	<name>JAXB2 Basics - Samples</name>
+	<name>JAXB Tools :: JAXB Basics :: Samples</name>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
-		<artifactId>jaxb2-basics-project</artifactId>
+		<groupId>org.jvnet.jaxb</groupId>
+		<artifactId>jaxb-basics-project</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<modules>

--- a/basics/testing/pom.xml
+++ b/basics/testing/pom.xml
@@ -2,10 +2,10 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jaxb2-basics-testing</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Testing</name>
+	<name>JAXB Tools :: JAXB Basics :: Testing</name>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
-		<artifactId>jaxb2-basics-project</artifactId>
+		<groupId>org.jvnet.jaxb</groupId>
+		<artifactId>jaxb-basics-project</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<dependencies>
@@ -24,11 +24,11 @@
 			<artifactId>commons-io</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-tools</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
 		</dependency>
 		<dependency>

--- a/basics/tests/JAXB-1058/pom.xml
+++ b/basics/tests/JAXB-1058/pom.xml
@@ -3,21 +3,21 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-JAXB-1058</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [JAXB-1058]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [JAXB-1058]</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2.maven2</groupId>
-			<artifactId>maven-jaxb2-plugin-testing</artifactId>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-testing</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics</artifactId>
 		</dependency>
 	</dependencies>
@@ -25,8 +25,8 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -34,7 +34,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 					</plugins>

--- a/basics/tests/commons_lang/pom.xml
+++ b/basics/tests/commons_lang/pom.xml
@@ -3,17 +3,17 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-commonslang</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [commons_lang]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [commons_lang]</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2.maven2</groupId>
-			<artifactId>maven-jaxb2-plugin-testing</artifactId>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-testing</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -26,8 +26,8 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -35,7 +35,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 					</plugins>

--- a/basics/tests/defaultvalue/pom.xml
+++ b/basics/tests/defaultvalue/pom.xml
@@ -3,21 +3,21 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-defaultvalue</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [default-value]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [default-value]</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2.maven2</groupId>
-			<artifactId>maven-jaxb2-plugin-testing</artifactId>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-testing</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
 		</dependency>
 	</dependencies>
@@ -25,8 +25,8 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -34,7 +34,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 					</plugins>

--- a/basics/tests/episodes/a/pom.xml
+++ b/basics/tests/episodes/a/pom.xml
@@ -3,19 +3,19 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-test-episodes</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-episodes-a</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [episodes-a]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [episodes-a]</name>
 	<build>
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -27,7 +27,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 					</plugins>

--- a/basics/tests/episodes/b/pom.xml
+++ b/basics/tests/episodes/b/pom.xml
@@ -3,16 +3,16 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-test-episodes</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-episodes-b</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [episodes-b]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [episodes-b]</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-test-episodes-a</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -21,8 +21,8 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -34,13 +34,13 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 					</plugins>
 					<episodes>
 						<episode>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics-test-episodes-a</artifactId>
 						</episode>
 					</episodes>

--- a/basics/tests/episodes/pom.xml
+++ b/basics/tests/episodes/pom.xml
@@ -3,13 +3,13 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-episodes</artifactId>
 	<packaging>pom</packaging>
-	<name>JAXB2 Basics - Test [episodes]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [episodes]</name>
 	<modules>
 		<module>a</module>
 		<module>b</module>

--- a/basics/tests/ignoring/pom.xml
+++ b/basics/tests/ignoring/pom.xml
@@ -3,19 +3,19 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-ignoring</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [ignoring]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [ignoring]</name>
 	<build>
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -27,7 +27,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 					</plugins>

--- a/basics/tests/issues/pom.xml
+++ b/basics/tests/issues/pom.xml
@@ -3,21 +3,21 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-issues</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [issues]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [issues]</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2.maven2</groupId>
-			<artifactId>maven-jaxb2-plugin-testing</artifactId>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-testing</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics</artifactId>
 		</dependency>
 	</dependencies>
@@ -25,8 +25,8 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -54,7 +54,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 					</plugins>

--- a/basics/tests/issues/src/test/java/org/jvnet/jaxb2_commons/tests/issues/RunIssuesPlugin.java
+++ b/basics/tests/issues/src/test/java/org/jvnet/jaxb2_commons/tests/issues/RunIssuesPlugin.java
@@ -3,8 +3,8 @@ package org.jvnet.jaxb2_commons.tests.issues;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb2.maven2.AbstractXJC2Mojo;
-import org.jvnet.jaxb2.maven2.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
+import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
 
 public class RunIssuesPlugin extends RunXJC2Mojo {
 

--- a/basics/tests/namespace/pom.xml
+++ b/basics/tests/namespace/pom.xml
@@ -3,21 +3,21 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-namespace</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [namespace]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [namespace]</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2.maven2</groupId>
-			<artifactId>maven-jaxb2-plugin-testing</artifactId>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-testing</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
 		</dependency>
 	</dependencies>
@@ -25,8 +25,8 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -34,7 +34,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 					</plugins>

--- a/basics/tests/namespace/src/test/java/org/jvnet/jaxb2_commons/tests/namespace/RunNamespacePlugin.java
+++ b/basics/tests/namespace/src/test/java/org/jvnet/jaxb2_commons/tests/namespace/RunNamespacePlugin.java
@@ -3,8 +3,8 @@ package org.jvnet.jaxb2_commons.tests.namespace;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb2.maven2.AbstractXJC2Mojo;
-import org.jvnet.jaxb2.maven2.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
+import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
 
 public class RunNamespacePlugin extends RunXJC2Mojo {
 	

--- a/basics/tests/one/pom.xml
+++ b/basics/tests/one/pom.xml
@@ -3,21 +3,21 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-one</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [one]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [one]</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2.maven2</groupId>
-			<artifactId>maven-jaxb2-plugin-testing</artifactId>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-testing</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics</artifactId>
 		</dependency>
 	</dependencies>
@@ -25,8 +25,8 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -38,7 +38,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
                                        </plugins>

--- a/basics/tests/one/src/test/java/org/jvnet/jaxb2_commons/tests/one/RunOnePlugin.java
+++ b/basics/tests/one/src/test/java/org/jvnet/jaxb2_commons/tests/one/RunOnePlugin.java
@@ -3,8 +3,8 @@ package org.jvnet.jaxb2_commons.tests.one;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb2.maven2.AbstractXJC2Mojo;
-import org.jvnet.jaxb2.maven2.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
+import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
 
 public class RunOnePlugin extends RunXJC2Mojo {
 	

--- a/basics/tests/po/pom.xml
+++ b/basics/tests/po/pom.xml
@@ -3,21 +3,21 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>0.11.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-po</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [po]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [po]</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2.maven2</groupId>
-			<artifactId>maven-jaxb2-plugin-testing</artifactId>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-testing</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics</artifactId>
 		</dependency>
 	</dependencies>
@@ -25,8 +25,8 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -35,7 +35,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
                                        </plugins>

--- a/basics/tests/pom.xml
+++ b/basics/tests/pom.xml
@@ -4,10 +4,10 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jaxb2-basics-tests</artifactId>
 	<packaging>pom</packaging>
-	<name>JAXB2 Basics - Tests</name>
+	<name>JAXB Tools :: JAXB Basics :: Tests</name>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
-		<artifactId>jaxb2-basics-project</artifactId>
+		<groupId>org.jvnet.jaxb</groupId>
+		<artifactId>jaxb-basics-project</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<modules>
@@ -32,7 +32,7 @@
 			<artifactId>jaxb-runtime</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
 		</dependency>
 		<dependency>
@@ -40,7 +40,7 @@
 			<artifactId>jakarta.activation</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-testing</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/basics/tests/simple-hashCode-equals-01/pom.xml
+++ b/basics/tests/simple-hashCode-equals-01/pom.xml
@@ -3,21 +3,21 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-tests-simple-hashCode-equals-01</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [simple-hashCode-equals-01]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [simple-hashCode-equals-01]</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2.maven2</groupId>
-			<artifactId>maven-jaxb2-plugin-testing</artifactId>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-testing</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics</artifactId>
 		</dependency>
 	</dependencies>
@@ -25,8 +25,8 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -36,7 +36,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 					</plugins>

--- a/basics/tests/simplify-01/pom.xml
+++ b/basics/tests/simplify-01/pom.xml
@@ -3,21 +3,21 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-simplify-01</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [simplify-01]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [simplify-01]</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2.maven2</groupId>
-			<artifactId>maven-jaxb2-plugin-testing</artifactId>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-testing</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics</artifactId>
 		</dependency>
 		<dependency>
@@ -29,8 +29,8 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -39,7 +39,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 					</plugins>

--- a/basics/tests/simplify-02/pom.xml
+++ b/basics/tests/simplify-02/pom.xml
@@ -3,21 +3,21 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-simplify-02</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [simplify-02]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [simplify-02]</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2.maven2</groupId>
-			<artifactId>maven-jaxb2-plugin-testing</artifactId>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-testing</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics</artifactId>
 		</dependency>
 		<dependency>
@@ -29,8 +29,8 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<!-- plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -38,7 +38,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 					</plugins>

--- a/basics/tests/superclass/a/pom.xml
+++ b/basics/tests/superclass/a/pom.xml
@@ -3,19 +3,19 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-test-superclass</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-superclass-a</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [superclass-a]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [superclass-a]</name>
 	<build>
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -27,7 +27,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 					</plugins>

--- a/basics/tests/superclass/b/pom.xml
+++ b/basics/tests/superclass/b/pom.xml
@@ -3,27 +3,27 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-test-superclass</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-superclass-b</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [superclass-b]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [superclass-b]</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-test-superclass-a</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2.maven2</groupId>
-			<artifactId>maven-jaxb2-plugin-testing</artifactId>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-testing</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -31,8 +31,8 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -44,17 +44,17 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
                                                 	<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics-test-superclass-a</artifactId>
 						</plugin>
 					</plugins>
 					<!--episodes>
 						<episode>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics-test-superclass-a</artifactId>
 						</episode>
 					</episodes-->

--- a/basics/tests/superclass/pom.xml
+++ b/basics/tests/superclass/pom.xml
@@ -3,13 +3,13 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-superclass</artifactId>
 	<packaging>pom</packaging>
-	<name>JAXB2 Basics - Test [superclass]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [superclass]</name>
 	<modules>
 		<module>a</module>
 		<module>b</module>

--- a/basics/tests/wildcard/pom.xml
+++ b/basics/tests/wildcard/pom.xml
@@ -3,21 +3,21 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-wildcard</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [wildcard]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [wildcard]</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2.maven2</groupId>
-			<artifactId>maven-jaxb2-plugin-testing</artifactId>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-testing</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics</artifactId>
 		</dependency>
 	</dependencies>
@@ -25,8 +25,8 @@
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<extension>true</extension>
 					<args>
@@ -34,7 +34,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 					</plugins>

--- a/basics/tests/zj/pom.xml
+++ b/basics/tests/zj/pom.xml
@@ -3,19 +3,19 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
+		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb2-basics-tests</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb2-basics-test-zj</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Test [zj]</name>
+	<name>JAXB Tools :: JAXB Basics :: Test [zj]</name>
 	<build>
 		<defaultGoal>test</defaultGoal>
 		<plugins>
 			<plugin>
-				<groupId>org.jvnet.jaxb2.maven2</groupId>
-				<artifactId>maven-jaxb2-plugin</artifactId>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
 				<configuration>
 					<args>
 						<arg>-XtoString</arg>
@@ -25,7 +25,7 @@
 					</args>
 					<plugins>
 						<plugin>
-							<groupId>org.jvnet.jaxb2_commons</groupId>
+							<groupId>org.jvnet.jaxb</groupId>
 							<artifactId>jaxb2-basics</artifactId>
 						</plugin>
 					</plugins>

--- a/basics/tools/pom.xml
+++ b/basics/tools/pom.xml
@@ -2,10 +2,10 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jaxb2-basics-tools</artifactId>
 	<packaging>jar</packaging>
-	<name>JAXB2 Basics - Tools</name>
+	<name>JAXB Tools :: JAXB Basics :: Tools</name>
 	<parent>
-		<groupId>org.jvnet.jaxb2_commons</groupId>
-		<artifactId>jaxb2-basics-project</artifactId>
+		<groupId>org.jvnet.jaxb</groupId>
+		<artifactId>jaxb-basics-project</artifactId>
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<dependencies>
@@ -26,7 +26,7 @@
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
 		</dependency>
 		<dependency>

--- a/basics/tools/src/test/java/org/jvnet/jaxb2_commons/reflection/util/test/FieldAccessorTest.java
+++ b/basics/tools/src/test/java/org/jvnet/jaxb2_commons/reflection/util/test/FieldAccessorTest.java
@@ -12,10 +12,10 @@ public class FieldAccessorTest {
 
 	@Test
 	public void testGetAndSet() throws URISyntaxException {
-		final URI uri = new URI("urn:test");
+		final URIInternalTest uri = new URIInternalTest("urn:test");
 
 		final Accessor<String> schemeAccessor = new FieldAccessor<String>(
-				URI.class, "scheme", String.class);
+				URIInternalTest.class, "scheme", String.class);
 
 		Assert.assertEquals("urn", schemeAccessor.get(uri));
 		schemeAccessor.set(uri, "nru");

--- a/basics/tools/src/test/java/org/jvnet/jaxb2_commons/reflection/util/test/URIInternalTest.java
+++ b/basics/tools/src/test/java/org/jvnet/jaxb2_commons/reflection/util/test/URIInternalTest.java
@@ -1,0 +1,17 @@
+package org.jvnet.jaxb2_commons.reflection.util.test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class URIInternalTest {
+    private transient String scheme;            // null ==> relative URI
+
+    public URIInternalTest(String uri) throws URISyntaxException {
+        URI internalUri = new URI(uri);
+        this.scheme = internalUri.getScheme();
+    }
+
+    public String getScheme() {
+        return scheme;
+    }
+}

--- a/maven-plugin/dist/pom.xml
+++ b/maven-plugin/dist/pom.xml
@@ -3,11 +3,11 @@
 	<groupId>org.jvnet.jaxb</groupId>
 	<artifactId>jaxb-maven-plugin-dist</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Dist</name>
+	<name>JAXB Tools :: Maven Plugin :: Distribution</name>
 	<parent>
 		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb-maven-plugin-project</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<dependency>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -26,7 +26,6 @@
 		<dtd-parser.version>1.4.5</dtd-parser.version>
 		<istack.version>3.0.12</istack.version>
 		<activation.version>1.2.2</activation.version>
-		<jaxb2-basics.version>0.12.0</jaxb2-basics.version>
 		<maven.plugin.testing.version>2.1</maven.plugin.testing.version>
 		<maven.plugin.plugin.version>3.7.1</maven.plugin.plugin.version>
 		<maven-nexus-staging-maven-plugin.version>1.6.8</maven-nexus-staging-maven-plugin.version>

--- a/maven-plugin/samples/catalog/pom.xml
+++ b/maven-plugin/samples/catalog/pom.xml
@@ -3,11 +3,11 @@
 	<groupId>org.jvnet.jaxb</groupId>
 	<artifactId>jaxb-maven-plugin-sample-catalog</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Sample [catalog]</name>
+	<name>JAXB Tools :: Maven Plugin :: Sample [catalog]</name>
 	<parent>
 		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb-maven-plugin-samples</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<build>
 		<defaultGoal>install</defaultGoal>

--- a/maven-plugin/samples/dtd/pom.xml
+++ b/maven-plugin/samples/dtd/pom.xml
@@ -3,11 +3,11 @@
 	<groupId>org.jvnet.jaxb</groupId>
 	<artifactId>jaxb-maven-plugin-sample-dtd</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Sample [dtd]</name>
+	<name>JAXB Tools :: Maven Plugin :: Sample [dtd]</name>
 	<parent>
 		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb-maven-plugin-samples</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<build>
 		<defaultGoal>install</defaultGoal>

--- a/maven-plugin/samples/episode/pom.xml
+++ b/maven-plugin/samples/episode/pom.xml
@@ -3,11 +3,11 @@
 	<groupId>org.jvnet.jaxb</groupId>
 	<artifactId>jaxb-maven-plugin-sample-episode</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Sample [episode]</name>
+	<name>JAXB Tools :: Maven Plugin :: Sample [episode]</name>
 	<parent>
 		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb-maven-plugin-samples</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<build>
 		<defaultGoal>install</defaultGoal>

--- a/maven-plugin/samples/jaxbplugins/pom.xml
+++ b/maven-plugin/samples/jaxbplugins/pom.xml
@@ -3,11 +3,11 @@
 	<groupId>org.jvnet.jaxb</groupId>
 	<artifactId>jaxb-maven-plugin-sample-jaxbplugins</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Sample [jaxbplugins]</name>
+	<name>JAXB Tools :: Maven Plugin :: Sample [jaxbplugins]</name>
 	<parent>
 		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb-maven-plugin-samples</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<build>
 		<defaultGoal>install</defaultGoal>

--- a/maven-plugin/samples/jaxbplugins/project-pom.xml
+++ b/maven-plugin/samples/jaxbplugins/project-pom.xml
@@ -14,9 +14,9 @@
 			<version>${jaxb.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
-			<version>${jaxb2-basics.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 	<build>
@@ -40,9 +40,9 @@
 							</args>
 							<plugins>
 								<plugin>
-									<groupId>org.jvnet.jaxb2_commons</groupId>
+									<groupId>org.jvnet.jaxb</groupId>
 									<artifactId>jaxb2-basics</artifactId>
-									<version>${jaxb2-basics.version}</version>
+									<version>${project.version}</version>
 								</plugin>
 							</plugins>
 						</configuration>

--- a/maven-plugin/samples/po/pom.xml
+++ b/maven-plugin/samples/po/pom.xml
@@ -3,11 +3,11 @@
 	<groupId>org.jvnet.jaxb</groupId>
 	<artifactId>jaxb-maven-plugin-sample-po</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Sample [po]</name>
+	<name>JAXB Tools :: Maven Plugin :: Sample [po]</name>
 	<parent>
 		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb-maven-plugin-samples</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<build>
 		<defaultGoal>install</defaultGoal>

--- a/maven-plugin/samples/pom.xml
+++ b/maven-plugin/samples/pom.xml
@@ -3,11 +3,11 @@
 	<groupId>org.jvnet.jaxb</groupId>
 	<artifactId>jaxb-maven-plugin-samples</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Samples</name>
+	<name>JAXB Tools :: Maven Plugin :: Samples</name>
 	<parent>
 		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb-maven-plugin-project</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.4-SNAPSHOT</version>
 	</parent>
         <dependencies>
             <dependency>
@@ -15,6 +15,12 @@
                 <artifactId>jaxb-maven-plugin</artifactId>
                 <version>${project.version}</version>
                 <type>maven-plugin</type>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jvnet.jaxb</groupId>
+                <artifactId>jaxb2-basics</artifactId>
+                <version>${project.version}</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>
@@ -40,7 +46,7 @@
 						<!--phase>package</phase-->
 						<phase>none</phase>
 						<goals>
-							 <goal>attached</goal>
+							 <goal>single</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -53,10 +59,10 @@
 						<!--phase>pre-integration-test</phase-->
 						<phase>none</phase>
 						<configuration>
-							<tasks>
+							<target>
 								<mkdir dir="target/test-maven-repository" />
 								<unzip src="target/${project.artifactId}-${project.version}-maven-src.zip" dest="${basedir}/target/test-maven-assembly" />
-							</tasks>
+							</target>
 						</configuration>
 						<goals>
 							<goal>run</goal>

--- a/maven-plugin/testing/pom.xml
+++ b/maven-plugin/testing/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jaxb-maven-plugin-testing</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Testing</name>
+	<name>JAXB Tools :: Maven Plugin :: Testing</name>
 	<parent>
 		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb-maven-plugin-project</artifactId>

--- a/maven-plugin/tests/JAXB-1044/pom.xml
+++ b/maven-plugin/tests/JAXB-1044/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-JAXB-1044]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-JAXB-1044]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-49/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-49/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-49]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-49]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-53/a/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-53/a/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-MAVEN_JAXB2_PLUGIN-53-a</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-53:a]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-53:a]</name>
 	<build>
 		<defaultGoal>test</defaultGoal>
 		<plugins>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-53/b/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-53/b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-MAVEN_JAXB2_PLUGIN-53-b</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-53:b]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-53:b]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.jvnet.jaxb</groupId>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-53/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-53/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-MAVEN_JAXB2_PLUGIN-53</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-53]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-53]</name>
 	<modules>
 		<module>a</module>
 		<module>b</module>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-69/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-69/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-69]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-69]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-70/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-70/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-70]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-70]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-77/common-types/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-77/common-types/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-MAVEN_JAXB2_PLUGIN-77-common-types</artifactId>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-77:common-types]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-77:common-types]</name>
 	<build>
 		<plugins>
 			<plugin>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-77/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-77/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-MAVEN_JAXB2_PLUGIN-77</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-77]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-77]</name>
 	<modules>
 		<module>common-types</module>
 		<module>service</module>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-77/service/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-77/service/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-MAVEN_JAXB2_PLUGIN-77-service</artifactId>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-77:service]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-77:service]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.jvnet.jaxb</groupId>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-79/a/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-79/a/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-MAVEN_JAXB2_PLUGIN-79-a</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-79:a]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-79:a]</name>
 	<build>
 		<defaultGoal>test</defaultGoal>
 		<plugins>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-79/b/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-79/b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-MAVEN_JAXB2_PLUGIN-79-b</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-79:b]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-79:b]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.jvnet.jaxb</groupId>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-79/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-79/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-MAVEN_JAXB2_PLUGIN-79</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-79]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-79]</name>
 	<modules>
 		<module>a</module>
 		<module>b</module>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-82/a/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-82/a/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-MAVEN_JAXB2_PLUGIN-82-a</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-82:a]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-82:a]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-82/b/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-82/b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-MAVEN_JAXB2_PLUGIN-82-b</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-82:b]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-82:b]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.jvnet.jaxb</groupId>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-82/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-82/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-MAVEN_JAXB2_PLUGIN-82</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-82]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-82]</name>
 	<modules>
 		<module>a</module>
 		<module>b</module>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-86/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-86/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-86]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-86]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-87/pom.xml
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-87/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [MAVEN_JAXB2_PLUGIN-87]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [MAVEN_JAXB2_PLUGIN-87]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/catalog-xml/pom.xml
+++ b/maven-plugin/tests/catalog-xml/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-catalog-xml</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [catalog-xml]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [catalog-xml]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.jvnet.jaxb</groupId>

--- a/maven-plugin/tests/catalog/pom.xml
+++ b/maven-plugin/tests/catalog/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-catalog</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [catalog]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [catalog]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.jvnet.jaxb</groupId>

--- a/maven-plugin/tests/episodes/a/pom.xml
+++ b/maven-plugin/tests/episodes/a/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-episodes-a</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [episodes:a]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [episodes:a]</name>
 	<build>
 		<defaultGoal>test</defaultGoal>
 		<plugins>

--- a/maven-plugin/tests/episodes/b/pom.xml
+++ b/maven-plugin/tests/episodes/b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-episodes-b</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [episodes:b]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [episodes:b]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.jvnet.jaxb</groupId>

--- a/maven-plugin/tests/episodes/c/pom.xml
+++ b/maven-plugin/tests/episodes/c/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-episodes-c</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [episodes:c]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [episodes:c]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.jvnet.jaxb</groupId>

--- a/maven-plugin/tests/episodes/d/pom.xml
+++ b/maven-plugin/tests/episodes/d/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-episodes-d</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [episodes:d]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [episodes:d]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.jvnet.jaxb</groupId>

--- a/maven-plugin/tests/episodes/e/pom.xml
+++ b/maven-plugin/tests/episodes/e/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-episodes-e</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [episodes:e]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [episodes:e]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.jvnet.jaxb</groupId>

--- a/maven-plugin/tests/episodes/pom.xml
+++ b/maven-plugin/tests/episodes/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-episodes</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Tests [episodes]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [episodes]</name>
 	<modules>
 		<module>a</module>
 		<module>b</module>

--- a/maven-plugin/tests/gh-issue-16/pom.xml
+++ b/maven-plugin/tests/gh-issue-16/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [GitHub Issue #16]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [GitHub Issue #16]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/gh-issue-19/a/pom.xml
+++ b/maven-plugin/tests/gh-issue-19/a/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-gh-issue-19-a</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [GitHub Issue #19:a]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [GitHub Issue #19:a]</name>
 	<build>
 		<defaultGoal>test</defaultGoal>
 		<plugins>

--- a/maven-plugin/tests/gh-issue-19/b/pom.xml
+++ b/maven-plugin/tests/gh-issue-19/b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-gh-issue-19-b</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [GitHub Issue #19:b]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [GitHub Issue #19:b]</name>
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/maven-plugin/tests/gh-issue-19/pom.xml
+++ b/maven-plugin/tests/gh-issue-19/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-gh-issue-19</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Tests [GitHub Issue #19]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [GitHub Issue #19]</name>
 	<modules>
 		<module>a</module>
 		<module>b</module>

--- a/maven-plugin/tests/gh-issue-22/a/pom.xml
+++ b/maven-plugin/tests/gh-issue-22/a/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-gh-issue-22-a</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [GitHub Issue #22:a]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [GitHub Issue #22:a]</name>
 	<build>
 		<defaultGoal>test</defaultGoal>
 		<plugins>

--- a/maven-plugin/tests/gh-issue-22/b/pom.xml
+++ b/maven-plugin/tests/gh-issue-22/b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-gh-issue-22-b</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [GitHub Issue #22:b]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [GitHub Issue #22:b]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.jvnet.jaxb</groupId>

--- a/maven-plugin/tests/gh-issue-22/pom.xml
+++ b/maven-plugin/tests/gh-issue-22/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-gh-issue-22</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Tests [GitHub Issue #22]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [GitHub Issue #22]</name>
 	<modules>
 		<module>a</module>
 		<module>b</module>

--- a/maven-plugin/tests/gh-issue-23/one-non-strict/pom.xml
+++ b/maven-plugin/tests/gh-issue-23/one-non-strict/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-gh-issue-23-one-non-strict</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [GitHub Issue #23:one-non-strict]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [GitHub Issue #23:one-non-strict]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/gh-issue-23/pom.xml
+++ b/maven-plugin/tests/gh-issue-23/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-gh-issue-23</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Tests [GitHub Issue #23]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [GitHub Issue #23]</name>
 	<modules>
 		<module>one-non-strict</module>
 		<module>two-non-strict</module>

--- a/maven-plugin/tests/gh-issue-23/two-non-strict/pom.xml
+++ b/maven-plugin/tests/gh-issue-23/two-non-strict/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>jaxb-maven-plugin-tests-gh-issue-23-two-non-strict</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [GitHub Issue #23:two-non-strict]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [GitHub Issue #23:two-non-strict]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/gh-issue-58/pom.xml
+++ b/maven-plugin/tests/gh-issue-58/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [GitHub Issue #58]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [GitHub Issue #58]</name>
 	<dependencies>
 		<dependency>
 			<groupId>com.sun.xml.bind</groupId>

--- a/maven-plugin/tests/issues/pom.xml
+++ b/maven-plugin/tests/issues/pom.xml
@@ -8,7 +8,7 @@
                 <relativePath>../pom.xml</relativePath>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [issues]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [issues]</name>
 	<dependencies>
                 <dependency>
                         <groupId>jakarta.xml.bind</groupId>

--- a/maven-plugin/tests/java-9/pom.xml
+++ b/maven-plugin/tests/java-9/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [Java 9]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [Java 9]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/p_o/pom.xml
+++ b/maven-plugin/tests/p_o/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [p o]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [p o]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/po-2.3/pom.xml
+++ b/maven-plugin/tests/po-2.3/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [po-2.3]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [po-2.3]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/po-scd/pom.xml
+++ b/maven-plugin/tests/po-scd/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [po-scd]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [po-scd]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/pom.xml
+++ b/maven-plugin/tests/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jaxb-maven-plugin-tests</artifactId>
 	<packaging>pom</packaging>
-	<name>Maven JAXB Plugin Tests</name>
+	<name>JAXB Tools :: Maven Plugin :: Tests</name>
 	<parent>
 		<groupId>org.jvnet.jaxb</groupId>
 		<artifactId>jaxb-maven-plugin-project</artifactId>
@@ -10,6 +10,12 @@
                 <relativePath>../pom.xml</relativePath>
 	</parent>
         <dependencies>
+            <dependency>
+                <groupId>org.jvnet.jaxb</groupId>
+                <artifactId>jaxb2-basics</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
             <dependency>
                 <groupId>org.jvnet.jaxb</groupId>
                 <artifactId>jaxb-maven-plugin</artifactId>
@@ -50,20 +56,6 @@
 	<build>
 		<pluginManagement>
 			<plugins>
-				<plugin>
-					<groupId>org.jvnet.jaxb</groupId>
-					<artifactId>jaxb-maven-plugin</artifactId>
-					<version>${project.version}</version>
-					<executions>
-						<execution>
-							<id>generate</id>
-							<goals>
-								<goal>generate</goal>
-							</goals>
-							<phase>generate-sources</phase>
-						</execution>
-					</executions>
-				</plugin>
 				<plugin>
 					<groupId>org.jvnet.jaxb</groupId>
 					<artifactId>jaxb-maven-plugin</artifactId>

--- a/maven-plugin/tests/res/pom.xml
+++ b/maven-plugin/tests/res/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [res]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [res]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/rnc/pom.xml
+++ b/maven-plugin/tests/rnc/pom.xml
@@ -9,7 +9,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [rnc]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [rnc]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/tse/pom.xml
+++ b/maven-plugin/tests/tse/pom.xml
@@ -7,7 +7,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [tse]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [tse]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/two/pom.xml
+++ b/maven-plugin/tests/two/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<dependencies>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
 		</dependency>
 		<dependency>
@@ -23,7 +23,7 @@
 	</dependencies>
 	<artifactId>jaxb-maven-plugin-tests-two</artifactId>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [two]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [two]</name>
 	<build>
 		<defaultGoal>test</defaultGoal>
 		<plugins>
@@ -58,9 +58,9 @@
 							</args>
 							<plugins>
 								<plugin>
-									<groupId>org.jvnet.jaxb2_commons</groupId>
+									<groupId>org.jvnet.jaxb</groupId>
 									<artifactId>jaxb2-basics</artifactId>
-									<version>${jaxb2-basics.version}</version>
+									<version>${project.version}</version>
 								</plugin>
 							</plugins>
 						</configuration>

--- a/maven-plugin/tests/wsdl-file/pom.xml
+++ b/maven-plugin/tests/wsdl-file/pom.xml
@@ -9,7 +9,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [wsdl-file]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [wsdl-file]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/wsdl/pom.xml
+++ b/maven-plugin/tests/wsdl/pom.xml
@@ -9,7 +9,7 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [wsdl]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [wsdl]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/maven-plugin/tests/xjc-simple/pom.xml
+++ b/maven-plugin/tests/xjc-simple/pom.xml
@@ -7,14 +7,14 @@
 		<version>2.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>jar</packaging>
-	<name>Maven JAXB Plugin Tests [xjc-simple]</name>
+	<name>JAXB Tools :: Maven Plugin :: Test [xjc-simple]</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.jaxb2_commons</groupId>
+			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb2-basics-runtime</artifactId>
 		</dependency>
 	</dependencies>
@@ -38,9 +38,9 @@
 							</args>
 							<plugins>
 								<plugin>
-									<groupId>org.jvnet.jaxb2_commons</groupId>
+									<groupId>org.jvnet.jaxb</groupId>
 									<artifactId>jaxb2-basics</artifactId>
-									<version>0.12.0</version>
+									<version>${project.version}</version>
 								</plugin>
 							</plugins>
 							<extension>true</extension>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,6 @@
 		<jaxb23.version>2.3.7</jaxb23.version>
 		<jaxb-api.version>2.3.3</jaxb-api.version>
 		<jaxb.version>${jaxb23.version}</jaxb.version>
-		<jaxb2-basics.version>0.12.0</jaxb2-basics.version>
                 <junit4.version>4.13.2</junit4.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<stax-ex.version>1.8.3</stax-ex.version>
@@ -371,9 +370,9 @@
                         </dependency>
 			<!-- JAXB2 Basics -->
 			<dependency>
-				<groupId>org.jvnet.jaxb2_commons</groupId>
+				<groupId>org.jvnet.jaxb</groupId>
 				<artifactId>jaxb2-basics-runtime</artifactId>
-				<version>${jaxb2-basics.version}</version>
+				<version>${project.version}</version>
 			</dependency>
 
 		</dependencies>


### PR DESCRIPTION
Fixing build issues of PR #282 : build is now successfull on jdk8/11/17 with maven profile `-P all`

Renaming all modules to JAXB Tools :: ...
Fixing build dependencies of samples / tests of jaxb-maven-plugin on jaxb2-basics

Also fixes https://github.com/highsource/jaxb2-basics/issues/130
Also fixes build issue (reflection access disallowed for URI class) on jdk17 (creating new internal class)