### PR TITLE
Fixing issue 306 : do some change in systemId handling for xjc 2.3.4+

### DIFF
--- a/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/resolver/tools/MavenCatalogResolver.java
+++ b/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/resolver/tools/MavenCatalogResolver.java
@@ -48,10 +48,10 @@ public class MavenCatalogResolver extends
 	@Override
 	public String getResolvedEntity(String publicId, String systemId) {
 		getLog().debug(
-				MessageFormat.format("Resolving publicId [{0}], systemId [{1}].", publicId, systemId));
+				MessageFormat.format("MavenCatalogResolver : Resolving publicId [{0}], systemId [{1}].", publicId, systemId));
 		final String superResolvedEntity = super.getResolvedEntity(publicId, systemId);
 		getLog().debug(
-				MessageFormat.format("Parent resolver has resolved publicId [{0}], systemId [{1}] to [{2}].", publicId, systemId, superResolvedEntity));
+				MessageFormat.format("MavenCatalogResolver : Parent resolver has resolved publicId [{0}], systemId [{1}] to [{2}].", publicId, systemId, superResolvedEntity));
 		if (superResolvedEntity != null) {
 			systemId = superResolvedEntity;
 		}
@@ -64,7 +64,7 @@ public class MavenCatalogResolver extends
 			final URI uri = new URI(systemId);
 			if (URI_SCHEME_MAVEN.equals(uri.getScheme())) {
 				getLog().debug(
-						MessageFormat.format("Resolving systemId [{1}] as Maven dependency resource.", publicId, systemId));
+						MessageFormat.format("MavenCatalogResolver : Resolving systemId [{1}] as Maven dependency resource.", publicId, systemId));
 				final String schemeSpecificPart = uri.getSchemeSpecificPart();
 				try {
 					final DependencyResource dependencyResource = DependencyResource.valueOf(schemeSpecificPart);
@@ -74,32 +74,32 @@ public class MavenCatalogResolver extends
 						String resolved = url.toString();
 						getLog().debug(
 								MessageFormat.format(
-										"Resolved systemId [{1}] to [{2}].",
+										"MavenCatalogResolver : Resolved systemId [{1}] to [{2}].",
 										publicId, systemId, resolved));
 						return resolved;
 					} catch (Exception ex) {
 						getLog().error(
 								MessageFormat
-										.format("Error resolving dependency resource [{0}].",
+										.format("MavenCatalogResolver : Error resolving dependency resource [{0}].",
 												dependencyResource));
 					}
 				} catch (IllegalArgumentException iaex) {
 					getLog().error(
 							MessageFormat
-									.format("Error parsing dependency descriptor [{0}].",
+									.format("MavenCatalogResolver : Error parsing dependency descriptor [{0}].",
 											schemeSpecificPart));
 
 				}
 				getLog().error(
 						MessageFormat
-								.format("Failed to resolve systemId [{1}] as dependency resource. "
+								.format("MavenCatalogResolver : Failed to resolve systemId [{1}] as dependency resource. "
 										+ "Returning parent resolver result [{2}].",
 										publicId, systemId, superResolvedEntity));
 				return superResolvedEntity;
 			} else {
 				getLog().debug(
 						MessageFormat
-								.format("SystemId [{1}] is not a Maven dependency resource URI. "
+								.format("MavenCatalogResolver : SystemId [{1}] is not a Maven dependency resource URI. "
 										+ "Returning parent resolver result [{2}].",
 										publicId, systemId, superResolvedEntity));
 				return superResolvedEntity;
@@ -107,7 +107,7 @@ public class MavenCatalogResolver extends
 		} catch (URISyntaxException urisex) {
 			getLog().debug(
 					MessageFormat
-							.format("Coul not parse the systemId [{1}] as URI. "
+							.format("MavenCatalogResolver : Could not parse the systemId [{1}] as URI. "
 									+ "Returning parent resolver result [{2}].",
 									publicId, systemId, superResolvedEntity));
 			return superResolvedEntity;

--- a/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/resolver/tools/ReResolvingEntityResolverWrapper.java
+++ b/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/resolver/tools/ReResolvingEntityResolverWrapper.java
@@ -1,10 +1,6 @@
 package org.jvnet.jaxb.maven.resolver.tools;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.Optional;
 
@@ -39,36 +35,9 @@ public class ReResolvingEntityResolverWrapper implements EntityResolver {
 		} else {
 			log.debug(MessageFormat.format("ReResolvingEntityResolverWrapper : Resolved to publicId [{0}], systemId [{1}].", resolvedInputSource.getPublicId(), resolvedInputSource.getSystemId()));
 			final String pId = !StringUtils.isEmpty(publicId) ? publicId : resolvedInputSource.getPublicId();
-			final String sId = computeSystemId(systemId, resolvedInputSource.getSystemId(), log);
-			return new ReResolvingInputSourceWrapper(this.entityResolver, resolvedInputSource, pId, sId, resolvedInputSource.getPublicId(), resolvedInputSource.getSystemId());
+			final String sId = !StringUtils.isEmpty(systemId) ? systemId : resolvedInputSource.getSystemId();
+            log.debug(MessageFormat.format("ReResolvingEntityResolverWrapper : Final Resolved to publicId [{0}], systemId [{1}].", pId, sId));
+            return new ReResolvingInputSourceWrapper(this.entityResolver, this.log, resolvedInputSource, pId, sId);
 		}
-	}
-
-	private static String computeSystemId(String systemId, String resolvedSystemId, Log log) {
-		if (systemId == null) {
-			return resolvedSystemId;
-		}
-		if (resolvedSystemId == null) {
-			return systemId;
-		}
-		boolean fileExistsSystemId = checkFileExists(systemId, log);
-		boolean fileExistsResolvedSystemId = checkFileExists(resolvedSystemId, log);
-		return !StringUtils.isEmpty(systemId) && fileExistsSystemId ? systemId : fileExistsResolvedSystemId ? resolvedSystemId : systemId;
-	}
-
-	private static boolean checkFileExists(String sId, Log log) {
-		try {
-			URI uriSystemId = new URI(sId);
-			if ("file".equals(uriSystemId.getScheme())) {
-				if (!Files.exists(Paths.get(uriSystemId))) {
-					// resolved file does not exist, warn and let's continue with original systemId
-					log.warn(MessageFormat.format("ReResolvingEntityResolverWrapper : File {0} does not exists.", sId));
-					return false;
-				}
-			}
-		} catch (URISyntaxException ex) {
-			// ignore, let it be handled by parser as is
-		}
-		return true;
 	}
 }

--- a/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/resolver/tools/ReResolvingInputSourceWrapper.java
+++ b/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/resolver/tools/ReResolvingInputSourceWrapper.java
@@ -3,7 +3,14 @@ package org.jvnet.jaxb.maven.resolver.tools;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Optional;
 
+import com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser;
+import org.apache.maven.plugin.logging.Log;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -11,23 +18,60 @@ import org.xml.sax.SAXException;
 public class ReResolvingInputSourceWrapper extends InputSource {
 
 	private final EntityResolver entityResolver;
+
+    private final Log log;
+
 	private final InputSource inputSource;
 
-	private final String resolvedPublicId;
-	private final String resolvedSystemId;
-
-	public ReResolvingInputSourceWrapper(EntityResolver entityResolver,
-			InputSource inputSource, String publicId, String systemId,
-			 String resolvedPublicId, String resolvedSystemId) {
+	public ReResolvingInputSourceWrapper(EntityResolver entityResolver, Log log,
+			InputSource inputSource, String publicId, String systemId) {
 		this.entityResolver = entityResolver;
+        this.log = log;
 		this.inputSource = inputSource;
 		this.setPublicId(publicId);
 		this.setSystemId(systemId);
-		this.resolvedPublicId = resolvedPublicId;
-		this.resolvedSystemId = resolvedSystemId;
 	}
 
-	@Override
+    @Override
+    public String getSystemId() {
+        String systemId = super.getSystemId();
+        String callerClassName = getCallerClassName();
+        if (callerClassName.endsWith("domforest")) {
+            log.debug("ReResolvingInputSourceWrapper : Handling DOMForest xjc 2.3.4+ change");
+            // DomForest checks now if file in initial systemId exists and override it if it doesnt
+            //  --> This breaks CatalogResolution (JT-306)
+            // Do the check here, and if file doesn't exist, return the inputSource.systemId instead,
+            //  which is the resolved systemId of the resource
+            try {
+                URI uri = new URI(systemId);
+                if ("file".equals(uri.getScheme())) {
+                    if (!Files.exists(Paths.get(uri))) {
+                        log.debug("ReResolvingInputSourceWrapper : Initial systemId "
+                            + systemId + " is file, and does not exist"
+                            + ", returning inputSource.getSystemId() as systemId (" + inputSource.getSystemId() + ")");
+                        systemId = inputSource.getSystemId();
+                    }
+                }
+            } catch (URISyntaxException ex) {
+                //ignore, let it be handled by parser as is
+            }
+        }
+        return systemId;
+    }
+
+    /**
+     * Returns the caller className, in lowercase form
+     * @return the caller className of this method
+     */
+    private static String getCallerClassName() {
+        StackTraceElement[] trace = new Exception().getStackTrace();
+        // trace[0] === this method
+        // trace[1] === this class, getSystemId
+        // trace[2] === caller class name
+        return Optional.ofNullable(trace[2].getClassName()).map(c -> c.toLowerCase()).orElse("");
+    }
+
+    @Override
 	public Reader getCharacterStream() {
 		final Reader originalReader = inputSource.getCharacterStream();
 		if (originalReader == null) {
@@ -45,10 +89,7 @@ public class ReResolvingInputSourceWrapper extends InputSource {
 	private Reader getResolvedEntity() {
 		try {
 			InputSource resolvedEntity = this.entityResolver.resolveEntity(
-					getPublicId(), getSystemId());
-			if (resolvedEntity == null) {
-				resolvedEntity = this.entityResolver.resolveEntity(resolvedPublicId, resolvedSystemId);
-			}
+					getPublicId(), super.getSystemId());
 			if (resolvedEntity == null) {
 				return null;
 			} else {
@@ -73,7 +114,7 @@ public class ReResolvingInputSourceWrapper extends InputSource {
 		} else {
 			try {
 				InputSource resolvedEntity = this.entityResolver.resolveEntity(
-						getPublicId(), getSystemId());
+						getPublicId(), super.getSystemId());
 				if (resolvedEntity != null) {
 					return resolvedEntity.getByteStream();
 				} else {

--- a/maven-plugin/tests/jt-306/common-model/pom.xml
+++ b/maven-plugin/tests/jt-306/common-model/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>jaxb-maven-plugin-tests-306-common-model</artifactId>
+	<parent>
+		<groupId>org.jvnet.jaxb</groupId>
+		<artifactId>jaxb-maven-plugin-tests-306</artifactId>
+		<version>2.0.5-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<packaging>jar</packaging>
+
+  <name>JAXB Tools :: Maven Plugin :: Test [JAXB-TOOLS 306 - Common Model]</name>
+	<description>TODO</description>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>generate</id>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven-plugin/tests/jt-306/common-model/src/main/resources/META-INF/common.xjb
+++ b/maven-plugin/tests/jt-306/common-model/src/main/resources/META-INF/common.xjb
@@ -1,0 +1,8 @@
+<jxb:bindings version="2.1" xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema" schemaLocation="common.xsd">
+
+  <jxb:schemaBindings>
+    <jxb:package name="com.example.model.common" />
+  </jxb:schemaBindings>
+
+</jxb:bindings>

--- a/maven-plugin/tests/jt-306/common-model/src/main/resources/META-INF/common.xsd
+++ b/maven-plugin/tests/jt-306/common-model/src/main/resources/META-INF/common.xsd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="urn:example-com:model:common"
+  xmlns:tns="urn:example-com:model:common">
+
+<!-- ===================================== Attribute types ===================================== -->
+
+  <xs:simpleType name="owningGroup">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Templates" />
+      <xs:enumeration value="Motor" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="role">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Approval Engineer" />
+      <xs:enumeration value="Manufacturing" />
+      <xs:enumeration value="Assistant" />
+      <xs:enumeration value="Publisher" />
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/maven-plugin/tests/jt-306/helper-ws-model/pom.xml
+++ b/maven-plugin/tests/jt-306/helper-ws-model/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>jaxb-maven-plugin-tests-306-helper-ws-model</artifactId>
+	<parent>
+		<groupId>org.jvnet.jaxb</groupId>
+		<artifactId>jaxb-maven-plugin-tests-306</artifactId>
+		<version>2.0.5-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<packaging>jar</packaging>
+
+  <name>JAXB Tools :: Maven Plugin :: Test [JAXB-TOOLS 306 - Helper Web Service Model]</name>
+	<description>TODO</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-tests-306-common-model</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>generate</id>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+            <configuration>
+              <catalog>src/main/resources/META-INF/helper-catalog.xml</catalog>
+              <episodes>
+                <episode>
+                  <groupId>org.jvnet.jaxb</groupId>
+                  <artifactId>jaxb-maven-plugin-tests-306-common-model</artifactId>
+                </episode>
+              </episodes>
+            </configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven-plugin/tests/jt-306/helper-ws-model/src/main/resources/META-INF/helper-catalog.xml
+++ b/maven-plugin/tests/jt-306/helper-ws-model/src/main/resources/META-INF/helper-catalog.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <systemSuffix systemIdSuffix="common.xsd" uri="maven:org.jvnet.jaxb:jaxb-maven-plugin-tests-306-common-model!/META-INF/common.xsd" />
+</catalog>

--- a/maven-plugin/tests/jt-306/helper-ws-model/src/main/resources/META-INF/helper.xjb
+++ b/maven-plugin/tests/jt-306/helper-ws-model/src/main/resources/META-INF/helper.xjb
@@ -1,0 +1,10 @@
+<jxb:bindings version="2.1" xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+      xmlns:xs="http://www.w3.org/2001/XMLSchema" schemaLocation="helper.xsd">
+
+  <jxb:globalBindings fixedAttributeAsConstantProperty="true" />
+
+  <jxb:schemaBindings>
+    <jxb:package name="com.example.model.helper" />
+  </jxb:schemaBindings>
+
+</jxb:bindings>

--- a/maven-plugin/tests/jt-306/helper-ws-model/src/main/resources/META-INF/helper.xsd
+++ b/maven-plugin/tests/jt-306/helper-ws-model/src/main/resources/META-INF/helper.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="urn:example-com:model:helper"
+  xmlns:tns="urn:example-com:model:helper"
+  xmlns:common="urn:example-com:model:common">
+
+  <xs:import namespace="urn:example-com:model:common"
+    schemaLocation="common.xsd" />
+
+  <!-- ================================== SOAP Header Elements =============================== -->
+
+  <!-- =================================== SOAP Body Elements ================================ -->
+
+  <xs:complexType name="ReviewerGroup">
+    <xs:sequence>
+      <xs:element name="Reviewer" type="tns:Reviewer" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Reviewer">
+    <xs:attribute name="user" type="xs:string" use="required" />
+    <xs:attribute name="role" type="common:role" use="required" />
+    <xs:attribute name="name" type="xs:string" use="required" />
+    <xs:attribute name="mail" type="xs:string" use="required" />
+  </xs:complexType>
+
+  <!-- ===================================== Attribute Types ================================= -->
+
+</xs:schema>

--- a/maven-plugin/tests/jt-306/import-ws-model/pom.xml
+++ b/maven-plugin/tests/jt-306/import-ws-model/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>jaxb-maven-plugin-tests-306-import-ws-model</artifactId>
+	<parent>
+		<groupId>org.jvnet.jaxb</groupId>
+		<artifactId>jaxb-maven-plugin-tests-306</artifactId>
+		<version>2.0.5-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<packaging>jar</packaging>
+
+	<name>JAXB Tools :: Maven Plugin :: Test [JAXB-TOOLS 306 - Import Web Service Model]</name>
+	<description>TODO</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-tests-306-common-model</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jvnet.jaxb</groupId>
+			<artifactId>jaxb-maven-plugin-tests-306-helper-ws-model</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>generate</id>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+            <configuration>
+              <catalog>src/main/resources/META-INF/import-catalog.xml</catalog>
+              <episodes>
+                <episode>
+                  <groupId>org.jvnet.jaxb</groupId>
+                  <artifactId>jaxb-maven-plugin-tests-306-common-model</artifactId>
+                </episode>
+                <episode>
+                  <groupId>org.jvnet.jaxb</groupId>
+                  <artifactId>jaxb-maven-plugin-tests-306-helper-ws-model</artifactId>
+                </episode>
+              </episodes>
+            </configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven-plugin/tests/jt-306/import-ws-model/src/main/resources/META-INF/import-catalog.xml
+++ b/maven-plugin/tests/jt-306/import-ws-model/src/main/resources/META-INF/import-catalog.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <systemSuffix systemIdSuffix="common.xsd" uri="maven:org.jvnet.jaxb:jaxb-maven-plugin-tests-306-common-model!/META-INF/common.xsd" />
+  <systemSuffix systemIdSuffix="helper.xsd" uri="maven:org.jvnet.jaxb:jaxb-maven-plugin-tests-306-helper-ws-model!/META-INF/helper.xsd" />
+</catalog>

--- a/maven-plugin/tests/jt-306/import-ws-model/src/main/resources/META-INF/import.xjb
+++ b/maven-plugin/tests/jt-306/import-ws-model/src/main/resources/META-INF/import.xjb
@@ -1,0 +1,8 @@
+<jxb:bindings version="2.1" xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" schemaLocation="import.xsd">
+
+  <jxb:schemaBindings>
+    <jxb:package name="com.example.model._import" />
+  </jxb:schemaBindings>
+
+</jxb:bindings>

--- a/maven-plugin/tests/jt-306/import-ws-model/src/main/resources/META-INF/import.xsd
+++ b/maven-plugin/tests/jt-306/import-ws-model/src/main/resources/META-INF/import.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="urn:example-com:model:import"
+  xmlns:tns="urn:example-com:model:import"
+  xmlns:common="urn:example-com:model:common"
+  xmlns:helper="urn:example-com:model:helper">
+
+  <xs:import namespace="urn:example-com:model:common"
+    schemaLocation="common.xsd" />
+  <xs:import namespace="urn:example-com:model:helper"
+    schemaLocation="helper.xsd" />
+
+<!-- ================================== SOAP Header Elements =================================== -->
+
+  <xs:complexType name="Authorization">
+    <xs:attribute name="user" type="xs:string" use="required" />
+    <xs:attribute name="group" type="common:owningGroup" use="required" />
+    <xs:attribute name="role" type="common:role" use="required" />
+  </xs:complexType>
+
+<!-- =================================== SOAP Body Elements ==================================== -->
+
+  <xs:complexType name="Workflow">
+    <xs:sequence>
+      <xs:element name="ReviewerGroup" type="helper:ReviewerGroup" minOccurs="0" maxOccurs="4" />
+    </xs:sequence>
+    <xs:attribute name="name" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="Design Lock" />
+          <xs:enumeration value="Design Release" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="group" type="common:owningGroup" />
+  </xs:complexType>
+
+</xs:schema>

--- a/maven-plugin/tests/jt-306/pom.xml
+++ b/maven-plugin/tests/jt-306/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>jaxb-maven-plugin-tests-306</artifactId>
+	<parent>
+		<groupId>org.jvnet.jaxb</groupId>
+		<artifactId>jaxb-maven-plugin-tests</artifactId>
+		<version>2.0.5-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	<packaging>pom</packaging>
+	<name>JAXB Tools :: Maven Plugin :: Test [JAXB-TOOLS 306]</name>
+	<description>
+		This project tests Catalog resolution on complex projects.
+	</description>
+
+  <modules>
+    <module>common-model</module>
+    <module>import-ws-model</module>
+    <module>helper-ws-model</module>
+  </modules>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin-tests-306-common-model</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin-tests-306-import-ws-model</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jvnet.jaxb</groupId>
+				<artifactId>jaxb-maven-plugin-tests-306-helper-ws-model</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<defaultGoal>test</defaultGoal>
+    <pluginManagement>
+      <plugins>
+      <!-- Bug https://github.com/eclipse-ee4j/jaxb-ri/issues/1001 -->
+      <!-- Bug https://github.com/eclipse-ee4j/jaxb-ri/issues/1006 -->
+        <plugin>
+          <groupId>org.jvnet.jaxb</groupId>
+          <artifactId>jaxb-maven-plugin</artifactId>
+          <version>${project.version}</version>
+          <configuration>
+            <schemaIncludes>
+              <include>**/*.xsd</include>
+            </schemaIncludes>
+            <bindingIncludes>
+              <include>**/*.xjb</include>
+            </bindingIncludes>
+            <readOnly>true</readOnly>
+            <episode>true</episode>
+            <specVersion>2.3</specVersion>
+            <extension>true</extension>
+            <removeOldOutput>true</removeOldOutput>
+            <locale>en</locale>
+            <strict>false</strict>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+	</build>
+</project>

--- a/maven-plugin/tests/pom.xml
+++ b/maven-plugin/tests/pom.xml
@@ -56,6 +56,7 @@
 		<module>jt-250</module>
 		<module>jt-244</module>
 		<module>jt-194</module>
+    <module>jt-306</module>
 	</modules>
 	<build>
 		<plugins>


### PR DESCRIPTION
Better handling of issue #244 which was partial fixed in previous PR and lead to #306 new issue.

Rollback of initial change in #244.
Only present resolved SystemId to DomForest if initial systemId does not exists.
Logs in overriden `getSystemId` in debug mode to indicate change in systemId presented if caller is `DOMForest` and if initial systemId points to a file which doesn't exisits.
Fix #306 and also still fix #244

Extra change :
`MavenCatalogResolver` : Changing log format (adding class name)