### PR TITLE
[#40] Adding new mojo to simplify generate test-sources

### DIFF
--- a/maven-plugin/plugin/src/main/java/org/jvnet/jaxb/maven/XJC2TestMojo.java
+++ b/maven-plugin/plugin/src/main/java/org/jvnet/jaxb/maven/XJC2TestMojo.java
@@ -1,0 +1,100 @@
+package org.jvnet.jaxb.maven;
+
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import java.io.File;
+
+/**
+ * JAXB 2.x Test Mojo.
+ *
+ * Generates sources for testing purpose (ie in /target/generated-test-sources/xjc path).
+ *
+ * @author Aleksei Valikov (valikov@gmx.net)
+ */
+@Mojo(name = "generate-test", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, requiresDependencyResolution = ResolutionScope.TEST, requiresDependencyCollection = ResolutionScope.TEST, threadSafe = true)
+public class XJC2TestMojo extends XJC2Mojo {
+
+    /**
+     * <p>
+     * Generated code will be written under this directory.
+     * </p>
+     * <p>
+     * For instance, if you specify <code>generateDirectory="doe/ray"</code> and
+     * <code>generatePackage="org.here"</code>, then files are generated to
+     * <code>doe/ray/org/here</code>.
+     * </p>
+     */
+    @Parameter(defaultValue = "${project.build.directory}/generated-test-sources/xjc", property = "maven.xjc2.generateTestDirectory", required = true)
+    private File generateDirectory;
+
+    @Override
+    public File getGenerateDirectory() {
+        return generateDirectory;
+    }
+
+    @Override
+    public void setGenerateDirectory(File generateDirectory) {
+        this.generateDirectory = generateDirectory;
+
+        if (getEpisodeFile() == null) {
+            final File episodeFile = new File(getGenerateDirectory(),
+                "META-INF" + File.separator + "sun-jaxb.episode");
+            setEpisodeFile(episodeFile);
+        }
+    }
+
+    /**
+     * If set to true (default), adds target directory as a compile source root
+     * of this Maven project.
+     */
+    @Parameter(defaultValue = "false", property = "maven.xjc2.addCompileSourceRoot", required = false)
+    private boolean addCompileSourceRoot = true;
+
+    @Override
+    public boolean getAddCompileSourceRoot() {
+        return addCompileSourceRoot;
+    }
+
+    @Override
+    public void setAddCompileSourceRoot(boolean addCompileSourceRoot) {
+        this.addCompileSourceRoot = addCompileSourceRoot;
+    }
+
+    /**
+     * If set to true, adds target directory as a test compile source root of
+     * this Maven project. Default value is false.
+     */
+    @Parameter(defaultValue = "true", property = "maven.xjc2.addTestCompileSourceRoot", required = false)
+    private boolean addTestCompileSourceRoot = false;
+
+    @Override
+    public boolean getAddTestCompileSourceRoot() {
+        return addTestCompileSourceRoot;
+    }
+
+    @Override
+    public void setAddTestCompileSourceRoot(boolean addTestCompileSourceRoot) {
+        this.addTestCompileSourceRoot = addTestCompileSourceRoot;
+    }
+
+
+    /**
+     * The source directory containing *.xsd schema files. Notice that binding
+     * files are searched by default in this directory.
+     */
+    @Parameter(defaultValue = "src/test/resources", property = "maven.xjc2.schemaTestDirectory", required = true)
+    private File schemaDirectory;
+
+    @Override
+    public File getSchemaDirectory() {
+        return schemaDirectory;
+    }
+
+    @Override
+    public void setSchemaDirectory(File schemaDirectory) {
+        this.schemaDirectory = schemaDirectory;
+    }
+}

--- a/maven-plugin/plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/maven-plugin/plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -14,5 +14,18 @@
         </execute>
       </action>
     </pluginExecution>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>generate-test</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <execute>
+          <runOnConfiguration>true</runOnConfiguration>
+          <runOnIncremental>true</runOnIncremental>
+        </execute>
+      </action>
+    </pluginExecution>
   </pluginExecutions>
 </lifecycleMappingMetadata>

--- a/maven-plugin/tests/jt-40/generate/pom.xml
+++ b/maven-plugin/tests/jt-40/generate/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jaxb-maven-plugin-tests-jt-40-generate</artifactId>
+  <parent>
+    <groupId>org.jvnet.jaxb</groupId>
+    <artifactId>jaxb-maven-plugin-tests-jt-40</artifactId>
+    <version>2.0.6-SNAPSHOT</version>
+  </parent>
+  <packaging>jar</packaging>
+  <name>JAXB Tools :: Maven Plugin :: Test [jt-40:generate]</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jvnet.jaxb</groupId>
+        <artifactId>jaxb-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate</id>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>generate-test</id>
+            <goals>
+              <goal>generate-test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-plugin/tests/jt-40/generate/src/main/java/org/jvnet/jaxb/main/AFail.java
+++ b/maven-plugin/tests/jt-40/generate/src/main/java/org/jvnet/jaxb/main/AFail.java
@@ -1,0 +1,28 @@
+package org.jvnet.jaxb.main;
+
+import b.B2Type;
+
+/**
+ * Class that will fail outside unit test since PurchaseOrderType in only in test-sources scope.
+ */
+public class AFail {
+
+    public AFail() throws ClassNotFoundException {
+        this(Class.forName("generated.PurchaseOrderType").getName());
+    }
+
+    public AFail(String value) {
+        b = new B2Type();
+        b.setB2(value);
+    }
+
+    private B2Type b;
+
+    public B2Type getB() {
+        return b;
+    }
+
+    public void setB(B2Type b) {
+        this.b = b;
+    }
+}

--- a/maven-plugin/tests/jt-40/generate/src/main/java/org/jvnet/jaxb/main/ASuccess.java
+++ b/maven-plugin/tests/jt-40/generate/src/main/java/org/jvnet/jaxb/main/ASuccess.java
@@ -1,0 +1,28 @@
+package org.jvnet.jaxb.main;
+
+import b.B2Type;
+
+/**
+ * Class that will always success since B2Type in sources scope.
+ */
+public class ASuccess {
+
+    public ASuccess() {
+        this("OK");
+    }
+
+    public ASuccess(String value) {
+        b = new B2Type();
+        b.setB2(value);
+    }
+
+    private B2Type b;
+
+    public B2Type getB() {
+        return b;
+    }
+
+    public void setB(B2Type b) {
+        this.b = b;
+    }
+}

--- a/maven-plugin/tests/jt-40/generate/src/main/resources/b.xsd
+++ b/maven-plugin/tests/jt-40/generate/src/main/resources/b.xsd
@@ -1,0 +1,13 @@
+<xsd:schema
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="b"
+	xmlns:b="b"
+	elementFormDefault="qualified">
+
+	<xsd:element name="b2" type="b:B2Type"/>
+
+	<xsd:complexType name="B2Type">
+		<xsd:attribute name="b2" type="xsd:string" use="required"/>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/maven-plugin/tests/jt-40/generate/src/test/java/org/jvnet/jaxb/test/JT40Test.java
+++ b/maven-plugin/tests/jt-40/generate/src/test/java/org/jvnet/jaxb/test/JT40Test.java
@@ -1,0 +1,31 @@
+package org.jvnet.jaxb.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.jaxb.main.AFail;
+import org.jvnet.jaxb.main.ASuccess;
+
+public class JT40Test {
+
+    @Test
+    public void testGeneratedTestSourcesNoClassRefTestInMain() throws Exception {
+        ASuccess a = new ASuccess();
+        Assert.assertEquals("OK", a.getB().getB2());
+
+        ASuccess aOther = new ASuccess("OK Too");
+        Assert.assertEquals("OK Too", aOther.getB().getB2());
+    }
+
+    @Test
+    public void testGeneratedTestSourcesClassRefTestInMain() throws Exception {
+        try {
+            AFail a = new AFail();
+            Assert.assertEquals(generated.PurchaseOrderType.class.getName(), a.getB().getB2());
+        } catch (ClassNotFoundException e) {
+            Assert.fail("Exception thrown (but should not)");
+        }
+
+        AFail aOther = new AFail("OK");
+        Assert.assertEquals("OK", aOther.getB().getB2());
+    }
+}

--- a/maven-plugin/tests/jt-40/generate/src/test/resources/purchaseorder.xsd
+++ b/maven-plugin/tests/jt-40/generate/src/test/resources/purchaseorder.xsd
@@ -1,0 +1,66 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <xsd:annotation>
+    <xsd:documentation xml:lang="en">
+     Purchase order schema for Example.com.
+     Copyright 2000 Example.com. All rights reserved.
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:element name="purchaseOrder" type="PurchaseOrderType"/>
+
+  <xsd:element name="comment" type="xsd:string"/>
+
+  <xsd:complexType name="PurchaseOrderType">
+    <xsd:sequence>
+      <xsd:element name="shipTo" type="USAddress"/>
+      <xsd:element name="billTo" type="USAddress"/>
+      <xsd:element ref="comment" minOccurs="0"/>
+      <xsd:element name="items"  type="Items"/>
+    </xsd:sequence>
+    <xsd:attribute name="orderDate" type="xsd:date"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="USAddress">
+    <xsd:sequence>
+      <xsd:element name="name"   type="xsd:string"/>
+      <xsd:element name="street" type="xsd:string"/>
+      <xsd:element name="city"   type="xsd:string"/>
+      <xsd:element name="state"  type="xsd:string"/>
+      <xsd:element name="zip"    type="xsd:decimal"/>
+    </xsd:sequence>
+    <xsd:attribute name="country" type="xsd:NMTOKEN"
+                   fixed="US"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="Items">
+    <xsd:sequence>
+      <xsd:element name="item" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="productName" type="xsd:string"/>
+            <xsd:element name="quantity">
+              <xsd:simpleType>
+                <xsd:restriction base="xsd:positiveInteger">
+                  <xsd:maxExclusive value="100"/>
+                </xsd:restriction>
+              </xsd:simpleType>
+            </xsd:element>
+            <xsd:element name="USPrice"  type="xsd:decimal"/>
+            <xsd:element ref="comment"   minOccurs="0"/>
+            <xsd:element name="shipDate" type="xsd:date" minOccurs="0"/>
+          </xsd:sequence>
+          <xsd:attribute name="partNum" type="SKU" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- Stock Keeping Unit, a code for identifying products -->
+  <xsd:simpleType name="SKU">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="\d{3}-[A-Z]{2}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/maven-plugin/tests/jt-40/pom.xml
+++ b/maven-plugin/tests/jt-40/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jaxb-maven-plugin-tests-jt-40</artifactId>
+  <parent>
+    <groupId>org.jvnet.jaxb</groupId>
+    <artifactId>jaxb-maven-plugin-tests</artifactId>
+    <version>2.0.6-SNAPSHOT</version>
+  </parent>
+  <packaging>pom</packaging>
+  <name>JAXB Tools :: Maven Plugin :: Test [jt-40]</name>
+  <modules>
+    <module>generate</module>
+    <module>test</module>
+  </modules>
+</project>

--- a/maven-plugin/tests/jt-40/test/pom.xml
+++ b/maven-plugin/tests/jt-40/test/pom.xml
@@ -1,0 +1,18 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>jaxb-maven-plugin-tests-jt-40-test</artifactId>
+  <parent>
+    <groupId>org.jvnet.jaxb</groupId>
+    <artifactId>jaxb-maven-plugin-tests-jt-40</artifactId>
+    <version>2.0.6-SNAPSHOT</version>
+  </parent>
+  <packaging>jar</packaging>
+  <name>JAXB Tools :: Maven Plugin :: Test [jt-40:test]</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.jvnet.jaxb</groupId>
+      <artifactId>jaxb-maven-plugin-tests-jt-40-generate</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/maven-plugin/tests/jt-40/test/src/test/java/org/jvnet/jaxb/test/JT40Test.java
+++ b/maven-plugin/tests/jt-40/test/src/test/java/org/jvnet/jaxb/test/JT40Test.java
@@ -1,0 +1,31 @@
+package org.jvnet.jaxb.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.jaxb.main.AFail;
+import org.jvnet.jaxb.main.ASuccess;
+
+public class JT40Test {
+
+    @Test
+    public void testGeneratedTestSourcesNoClassRefTestInMain() throws Exception {
+        ASuccess a = new ASuccess();
+        Assert.assertEquals("OK", a.getB().getB2());
+
+        ASuccess aOther = new ASuccess("OK Too");
+        Assert.assertEquals("OK Too", aOther.getB().getB2());
+    }
+
+    @Test
+    public void testGeneratedTestSourcesClassRefTestInMain() throws Exception {
+        try {
+            new AFail();
+            Assert.fail("Exception not thrown");
+        } catch (ClassNotFoundException e) {
+            // OK
+        }
+
+        AFail aOther = new AFail("OK");
+        Assert.assertEquals("OK", aOther.getB().getB2());
+    }
+}

--- a/maven-plugin/tests/pom.xml
+++ b/maven-plugin/tests/pom.xml
@@ -57,6 +57,7 @@
     <module>jt-244</module>
     <module>jt-194</module>
     <module>jt-306</module>
+    <module>jt-40</module>
   </modules>
   <build>
     <plugins>


### PR DESCRIPTION
Fixes #40 : adding new mojo with default change value to generate `test-sources`
Fixes #205 : duplicate of #40 