### PR TITLE
[#188] Classloaders not being closed for mojo classloader

### DIFF
--- a/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/util/IOUtils.java
+++ b/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/util/IOUtils.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;


### PR DESCRIPTION
This will try to close `URLClassLoader` created by XJCMojo when no more needed to free resources earlier in build.
Fixes #188 