### PR TITLE
[#347] remove overridden properties in maven-plugin sub-module

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -15,22 +15,7 @@
     <module>plugin</module>
     <module>testing</module>
   </modules>
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.version>2.0.9</maven.version>
-    <jaxb23.version>2.3.7</jaxb23.version>
-    <jaxb-api.version>2.3.3</jaxb-api.version>
-    <jaxb.version>${jaxb23.version}</jaxb.version>
-    <stax-ex.version>1.8.3</stax-ex.version>
-    <fastinfoset.version>1.2.18</fastinfoset.version>
-    <dtd-parser.version>1.4.5</dtd-parser.version>
-    <istack.version>3.0.12</istack.version>
-    <activation.version>1.2.2</activation.version>
-    <maven.plugin.testing.version>2.1</maven.plugin.testing.version>
-    <maven.plugin.plugin.version>3.7.1</maven.plugin.plugin.version>
-    <maven-nexus-staging-maven-plugin.version>1.6.8</maven-nexus-staging-maven-plugin.version>
-    <slf4j.version>1.7.25</slf4j.version>
-  </properties>
+
   <profiles>
     <profile>
       <id>samples</id>
@@ -70,7 +55,7 @@
     </profile>
   </profiles>
   <dependencies>
-		<!-- JUnit -->
+    <!-- JUnit -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>


### PR DESCRIPTION
Fixes #347 and fixup of #354 by removing properties section in `maven-plugin/pom.xml`