### PR TITLE
Fixing JAXB-BOM (using ext artifact) and partial rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,22 +94,22 @@ If you need an older JAXB version, you can use one of the following variants, wh
 If you experience issues with the Mojohaus JAXB2 Maven Plugin (`org.codehaus.mojo:jaxb2-maven-plugin`),
 please file it [on their project page](https://github.com/mojohaus/jaxb2-maven-plugin).
 
-# JAXB2 Basics
+# JAXB Basics
 
-JAXB2 Basics is an [open source](https://github.com/highsource/jaxb-tools/blob/master/LICENSE) project
-which provides useful plugins and tools for [JAXB 2.x reference implementation](https://github.com/eclipse-ee4j/jaxb-ri/tree/EE8).
+JAXB Basics is an [open source](https://github.com/highsource/jaxb-tools/blob/master/LICENSE) project
+which provides useful plugins and tools for [JAXB 3.x reference implementation](https://github.com/eclipse-ee4j/jaxb-ri/tree/3.0.2-RI).
 
 ## Documentation
 
 Please refer to the [wiki](https://github.com/highsource/jaxb-tools/wiki/JAXB2-Basic) for documentation.
 
-JAXB2 Basics can only be used with JAXB/XJC 2.3.x. JAXB/XJC versions 2.2.x and earlier are no longer supported.
+JAXB Basics can only be used with JAXB/XJC 3.x.
 
-## Using JAXB2 Basics
+## Using JAXB Basics
 
-* [Using JAXB2 Basics Plugins](https://github.com/highsource/jaxb-tools/wiki/Using-JAXB2-Basics-Plugins)
+* [Using JAXB Basics Plugins](https://github.com/highsource/jaxb-tools/wiki/Using-JAXB2-Basics-Plugins)
 
-## JAXB2 Basics Plugins
+## JAXB Basics Plugins
 * [SimpleEquals Plugin](https://github.com/highsource/jaxb-tools/wiki/JAXB2-SimpleEquals-Plugin) - generates runtime-free reflection-free `equals(...)` methods.
 * [SimpleHashCode Plugin](https://github.com/highsource/jaxb-tools/wiki/JAXB2-SimpleHashCode-Plugin) - generates runtime-free reflection-free `hashCode()` methods.
 * [Equals Plugin](https://github.com/highsource/jaxb-tools/wiki/JAXB2-Equals-Plugin) - generates reflection-free strategic `equals(...)` method.
@@ -198,7 +198,7 @@ You can put your annotations directly in schema:
         <xsd:annotation>
             <xsd:appinfo>
                 <annox:annotate>@java.lang.SuppressWarnings({"unchecked","rawtypes"})</annox:annotate>
-                <annox:annotate target="package">@javax.annotation.Generated({"XJC","JAXB2 Annotate Plugin"})</annox:annotate>
+                <annox:annotate target="package">@javax.annotation.Generated({"XJC","JAXB Annotate Plugin"})</annox:annotate>
             </xsd:appinfo>
         </xsd:annotation>
         <xsd:sequence>
@@ -380,7 +380,7 @@ Note: yes, I know that `http://annox.dev.java.net` no longer exists. Changing th
 This is just a namespace, there must not necessarily be content there. Treat it as a logical identifier, nothing else.
 
 
-## Using JAXB2 Annotate Plugin with Maven
+## Using JAXB Annotate Plugin with Maven
 
 * Add `org.jvnet.jaxb:jaxb-basics-annotate` as XJC plugin
 * Turn on the plugin using `-Xannotate` or `-XremoveAnnotation`switch
@@ -416,7 +416,7 @@ See [this example](https://github.com/highsource/jaxb-tools/tree/master/jaxb-ann
 
 Note that annotations are first compiled in the `annotations` module and the added to the classpath of the `jaxb-maven-plugin` in the `schema` module:
 
-## Using JAXB2 Annotate Plugin with Ant
+## Using JAXB Annotate Plugin with Ant
 
 See [this example](https://github.com/highsource/jaxb-tools/blob/master/jaxb-annotate-parent/samples/annotate/project-build.xml).
 

--- a/basics/ant/src/main/java/org/jvnet/jaxb2_commons/xjc/XJCTask.java
+++ b/basics/ant/src/main/java/org/jvnet/jaxb2_commons/xjc/XJCTask.java
@@ -2,7 +2,7 @@ package org.jvnet.jaxb2_commons.xjc;
 
 import org.apache.tools.ant.BuildException;
 
-public class XJC2Task extends com.sun.tools.xjc.XJC2Task {
+public class XJCTask extends com.sun.tools.xjc.XJC2Task {
 
 	private boolean disableXmlSecurity = true;
 

--- a/basics/basic/src/main/java/org/jvnet/jaxb2_commons/plugin/simpleequals/SimpleEqualsPlugin.java
+++ b/basics/basic/src/main/java/org/jvnet/jaxb2_commons/plugin/simpleequals/SimpleEqualsPlugin.java
@@ -36,7 +36,7 @@ public class SimpleEqualsPlugin extends
 	@Override
 	public String getUsage() {
 		return "  -XsimpleEquals :  Generate reflection-free runtime-free equals(Object that) methods.\n" +
-	           "                    See https://github.com/highsource/jaxb2-basics/wiki/JAXB2-SimpleEquals-Plugin";
+	           "                    See https://github.com/highsource/jaxb-tools/wiki/JAXB2-SimpleEquals-Plugin";
 	}
 
 	@Override

--- a/basics/basic/src/main/java/org/jvnet/jaxb2_commons/plugin/simplehashcode/SimpleHashCodePlugin.java
+++ b/basics/basic/src/main/java/org/jvnet/jaxb2_commons/plugin/simplehashcode/SimpleHashCodePlugin.java
@@ -35,7 +35,7 @@ public class SimpleHashCodePlugin extends
 	@Override
 	public String getUsage() {
 		return "  -XsimpleEquals :  Generate reflection-free runtime-free hashCode() methods.\n" +
-		       "                    See https://github.com/highsource/jaxb2-basics/wiki/JAXB2-SimpleHashCode-Plugin";
+		       "                    See https://github.com/highsource/jaxb-tools/wiki/JAXB2-SimpleHashCode-Plugin";
 	}
 
 	@Override

--- a/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/copyable/tests/RunCopyablePlugin.java
+++ b/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/copyable/tests/RunCopyablePlugin.java
@@ -4,12 +4,12 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunCopyablePlugin extends RunXJC2Mojo {
+public class RunCopyablePlugin extends RunXJCMojo {
 
 	@Override
 	public File getSchemaDirectory() {
@@ -17,7 +17,7 @@ public class RunCopyablePlugin extends RunXJC2Mojo {
 	}
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 		mojo.setForceRegenerate(true);
 	}

--- a/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/equals/tests/RunEqualsPlugin.java
+++ b/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/equals/tests/RunEqualsPlugin.java
@@ -4,12 +4,12 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunEqualsPlugin extends RunXJC2Mojo {
+public class RunEqualsPlugin extends RunXJCMojo {
 
 	@Override
 	public File getSchemaDirectory() {
@@ -17,7 +17,7 @@ public class RunEqualsPlugin extends RunXJC2Mojo {
 	}
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 		mojo.setForceRegenerate(true);
 	}

--- a/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/mergeable/tests/RunMergeablePlugin.java
+++ b/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/mergeable/tests/RunMergeablePlugin.java
@@ -4,12 +4,12 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunMergeablePlugin extends RunXJC2Mojo {
+public class RunMergeablePlugin extends RunXJCMojo {
 
 	@Override
 	public File getSchemaDirectory() {
@@ -17,7 +17,7 @@ public class RunMergeablePlugin extends RunXJC2Mojo {
 	}
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 		mojo.setForceRegenerate(true);
 	}

--- a/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/tostring/tests/RunToStringPlugin.java
+++ b/basics/basic/src/test/java/org/jvnet/jaxb2_commons/plugin/tostring/tests/RunToStringPlugin.java
@@ -4,13 +4,13 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 import org.jvnet.jaxb2_commons.lang.JAXBToStringStrategy;
 
 import com.sun.tools.xjc.Options;
 
-public class RunToStringPlugin extends RunXJC2Mojo {
+public class RunToStringPlugin extends RunXJCMojo {
 
 	@Override
 	public File getSchemaDirectory() {
@@ -18,7 +18,7 @@ public class RunToStringPlugin extends RunXJC2Mojo {
 	}
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 		mojo.setForceRegenerate(true);
 	}

--- a/basics/samples/basic/project-build.xml
+++ b/basics/samples/basic/project-build.xml
@@ -69,8 +69,8 @@
     <delete dir="${basedir}/target/test-classes"/>
   </target>
   <target name="generate-sources">
-    <taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJC2Task">
-			<!-- XJC2 Task classpath -->
+    <taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJCTask">
+			<!-- XJC Task classpath -->
       <classpath>
         <fileset dir="${basedir}/lib">
           <include name="codemodel-*.jar"/>

--- a/basics/samples/po-simple/project-build.xml
+++ b/basics/samples/po-simple/project-build.xml
@@ -68,8 +68,8 @@
     <delete dir="${basedir}/target/test-classes"/>
   </target>
   <target name="generate-sources">
-    <taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJC2Task">
-			<!-- XJC2 Task classpath -->
+    <taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJCTask">
+			<!-- XJC Task classpath -->
       <classpath>
         <fileset dir="${basedir}/lib">
           <include name="codemodel-*.jar"/>

--- a/basics/samples/po/project-build.xml
+++ b/basics/samples/po/project-build.xml
@@ -68,8 +68,8 @@
     <delete dir="${basedir}/target/test-classes"/>
   </target>
   <target name="generate-sources">
-    <taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJC2Task">
-			<!-- XJC2 Task classpath -->
+    <taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJCTask">
+			<!-- XJC Task classpath -->
       <classpath>
         <fileset dir="${basedir}/lib">
           <include name="codemodel-*.jar"/>

--- a/basics/tests/issues/src/test/java/org/jvnet/jaxb2_commons/tests/issues/RunIssuesPlugin.java
+++ b/basics/tests/issues/src/test/java/org/jvnet/jaxb2_commons/tests/issues/RunIssuesPlugin.java
@@ -3,15 +3,15 @@ package org.jvnet.jaxb2_commons.tests.issues;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunIssuesPlugin extends RunXJC2Mojo {
+public class RunIssuesPlugin extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 		mojo.setExtension(true);
 		mojo.setForceRegenerate(true);

--- a/basics/tests/namespace/src/test/java/org/jvnet/jaxb2_commons/tests/namespace/RunNamespacePlugin.java
+++ b/basics/tests/namespace/src/test/java/org/jvnet/jaxb2_commons/tests/namespace/RunNamespacePlugin.java
@@ -3,15 +3,15 @@ package org.jvnet.jaxb2_commons.tests.namespace;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunNamespacePlugin extends RunXJC2Mojo {
+public class RunNamespacePlugin extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 		mojo.setExtension(true);
 		mojo.setForceRegenerate(true);

--- a/basics/tests/one/src/test/java/org/jvnet/jaxb2_commons/tests/one/RunOnePlugin.java
+++ b/basics/tests/one/src/test/java/org/jvnet/jaxb2_commons/tests/one/RunOnePlugin.java
@@ -3,15 +3,15 @@ package org.jvnet.jaxb2_commons.tests.one;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunOnePlugin extends RunXJC2Mojo {
+public class RunOnePlugin extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 		mojo.setExtension(true);
 		mojo.setForceRegenerate(true);

--- a/hyperjaxb/ejb/samples/po-customized-toplink/project-build.xml
+++ b/hyperjaxb/ejb/samples/po-customized-toplink/project-build.xml
@@ -80,8 +80,8 @@
 		<delete dir="${basedir}/target/test-classes"/>
 	</target>
 	<target name="generate-sources">
-		<taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJC2Task">
-			<!-- XJC2 Task classpath -->
+		<taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJCTask">
+			<!-- XJC Task classpath -->
 			<classpath>
 				<fileset dir="${basedir}/lib">
 					<include name="activation-*.jar"/>

--- a/hyperjaxb/ejb/samples/po-initial/project-build.xml
+++ b/hyperjaxb/ejb/samples/po-initial/project-build.xml
@@ -86,8 +86,8 @@
 	</target>
 	<target name="generate-sources">
 		<taskdef name="xjc" classname="com.sun.tools.xjc.XJC2Task">
-		<!--taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJC2Task"-->
-			<!-- XJC2 Task classpath -->
+		<!--taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJCTask"-->
+			<!-- XJC Task classpath -->
 			<classpath>
 				<fileset dir="${basedir}/lib">
 					<include name="activation-*.jar"/>

--- a/hyperjaxb/ejb/samples/uniprot/project-build.xml
+++ b/hyperjaxb/ejb/samples/uniprot/project-build.xml
@@ -85,8 +85,8 @@
 		<delete dir="${basedir}/target/test-classes"/>
 	</target>
 	<target name="generate-sources">
-		<taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJC2Task">
-			<!-- XJC2 Task classpath -->
+		<taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJCTask">
+			<!-- XJC Task classpath -->
 			<classpath>
 				<fileset dir="${basedir}/lib">
 					<include name="activation-*.jar"/>

--- a/hyperjaxb/ejb/templates/basic/project-build.xml
+++ b/hyperjaxb/ejb/templates/basic/project-build.xml
@@ -86,8 +86,8 @@
 		<delete dir="${basedir}/target/test-classes"/>
 	</target>
 	<target name="generate-sources">
-		<taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJC2Task">
-			<!-- XJC2 Task classpath -->
+		<taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJCTask">
+			<!-- XJC Task classpath -->
 			<classpath>
 				<fileset dir="${basedir}/lib">
 					<include name="activation-*.jar"/>

--- a/hyperjaxb/maven/plugin/src/main/java/org/jvnet/hyperjaxb3/maven2/Hyperjaxb3Mojo.java
+++ b/hyperjaxb/maven/plugin/src/main/java/org/jvnet/hyperjaxb3/maven2/Hyperjaxb3Mojo.java
@@ -38,10 +38,10 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import com.sun.tools.xjc.Options;
-import org.jvnet.jaxb.maven.XJC2Mojo;
+import org.jvnet.jaxb.maven.XJCMojo;
 
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE, threadSafe = true)
-public class Hyperjaxb3Mojo extends XJC2Mojo {
+public class Hyperjaxb3Mojo extends XJCMojo {
 
 	/**
 	 * Target directory for the generated mappings. If left empty, mappings are

--- a/hyperjaxb/maven/plugin/src/test/java/org/jvnet/hyperjaxb3/maven2/tests/Hyperjaxb3MojoTest.java
+++ b/hyperjaxb/maven/plugin/src/test/java/org/jvnet/hyperjaxb3/maven2/tests/Hyperjaxb3MojoTest.java
@@ -4,18 +4,18 @@ import java.io.File;
 
 import org.apache.maven.project.MavenProject;
 import org.jvnet.hyperjaxb3.maven2.Hyperjaxb3Mojo;
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
-public class Hyperjaxb3MojoTest extends RunXJC2Mojo {
+public class Hyperjaxb3MojoTest extends RunXJCMojo {
 
 	@Override
-	protected AbstractXJC2Mojo createMojo() {
+	protected AbstractXJCMojo createMojo() {
 		return new Hyperjaxb3Mojo();
 	}
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo mojo) {
+	protected void configureMojo(AbstractXJCMojo mojo) {
 		super.configureMojo(mojo);
 		configureHyperjaxb3Mojo((Hyperjaxb3Mojo) mojo);
 

--- a/hyperjaxb/maven/testing/src/main/java/org/jvnet/hyperjaxb3/maven2/ejb/test/RunEjbHyperjaxb3Mojo.java
+++ b/hyperjaxb/maven/testing/src/main/java/org/jvnet/hyperjaxb3/maven2/ejb/test/RunEjbHyperjaxb3Mojo.java
@@ -2,18 +2,18 @@ package org.jvnet.hyperjaxb3.maven2.ejb.test;
 
 import org.apache.maven.project.MavenProject;
 import org.jvnet.hyperjaxb3.maven2.Hyperjaxb3Mojo;
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
-public class RunEjbHyperjaxb3Mojo extends RunXJC2Mojo {
+public class RunEjbHyperjaxb3Mojo extends RunXJCMojo {
 
 	@Override
-	protected AbstractXJC2Mojo createMojo() {
+	protected AbstractXJCMojo createMojo() {
 		return new Hyperjaxb3Mojo();
 	}
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo mojo) {
+	protected void configureMojo(AbstractXJCMojo mojo) {
 		super.configureMojo(mojo);
 		configureHyperjaxb3Mojo((Hyperjaxb3Mojo) mojo);
 

--- a/jaxb-annotate-parent/samples/annotate/project-build.xml
+++ b/jaxb-annotate-parent/samples/annotate/project-build.xml
@@ -74,8 +74,8 @@
     <delete dir="${basedir}/target/test-classes"/>
   </target>
   <target name="generate-sources">
-    <taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJC2Task">
-			<!-- XJC2 Task classpath -->
+    <taskdef name="xjc" classname="org.jvnet.jaxb2_commons.xjc.XJCTask">
+			<!-- XJC Task classpath -->
       <classpath>
         <fileset dir="${basedir}/lib">
           <include name="commons-text-*.jar"/>

--- a/jaxb-annotate-parent/tests/annotate/src/test/java/org/jvnet/jaxb2_commons/tests/annotate/RunAnnotatePlugin.java
+++ b/jaxb-annotate-parent/tests/annotate/src/test/java/org/jvnet/jaxb2_commons/tests/annotate/RunAnnotatePlugin.java
@@ -31,15 +31,15 @@ package org.jvnet.jaxb2_commons.tests.annotate;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunAnnotatePlugin extends RunXJC2Mojo {
+public class RunAnnotatePlugin extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 		mojo.setExtension(true);
 		mojo.setForceRegenerate(true);

--- a/jaxb-annotate-parent/tests/issues/src/test/java/org/jvnet/jaxb2_commons/tests/issues/tests/RunIssuesPlugin.java
+++ b/jaxb-annotate-parent/tests/issues/src/test/java/org/jvnet/jaxb2_commons/tests/issues/tests/RunIssuesPlugin.java
@@ -31,15 +31,15 @@ package org.jvnet.jaxb2_commons.tests.issues.tests;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunIssuesPlugin extends RunXJC2Mojo {
+public class RunIssuesPlugin extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 		mojo.setExtension(true);
 		mojo.setForceRegenerate(true);

--- a/jaxb-annotate-parent/tests/one/src/test/java/org/jvnet/jaxb2_commons/tests/one/RunOnePlugin.java
+++ b/jaxb-annotate-parent/tests/one/src/test/java/org/jvnet/jaxb2_commons/tests/one/RunOnePlugin.java
@@ -31,15 +31,15 @@ package org.jvnet.jaxb2_commons.tests.one;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunOnePlugin extends RunXJC2Mojo {
+public class RunOnePlugin extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 		mojo.setExtension(true);
 		mojo.setForceRegenerate(true);

--- a/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/AbstractXJCMojo.java
+++ b/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/AbstractXJCMojo.java
@@ -38,7 +38,7 @@ import org.jvnet.jaxb.maven.util.IOUtils;
 import org.sonatype.plexus.build.incremental.BuildContext;
 import org.sonatype.plexus.build.incremental.DefaultBuildContext;
 
-public abstract class AbstractXJC2Mojo<O> extends AbstractMojo implements
+public abstract class AbstractXJCMojo<O> extends AbstractMojo implements
 		DependencyResourceResolver {
 
 	@Parameter(defaultValue = "${settings}", readonly = true)
@@ -767,7 +767,7 @@ public abstract class AbstractXJC2Mojo<O> extends AbstractMojo implements
 	/**
 	 * <p>
 	 * A list of extra XJC's command-line arguments (items must include the dash
-	 * '-'). Use this argument to enable the JAXB2 plugins you want to use.
+	 * '-'). Use this argument to enable the JAXB plugins you want to use.
 	 * </p>
 	 * <p>
 	 * Arguments set here take precedence over other mojo parameters.

--- a/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/RawXJCMojo.java
+++ b/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/RawXJCMojo.java
@@ -88,12 +88,12 @@ import com.sun.xml.txw2.annotation.XmlNamespace;
  *
  * @author Aleksei Valikov (valikov@gmx.net)
  */
-public abstract class RawXJC2Mojo<O> extends AbstractXJC2Mojo<O> {
+public abstract class RawXJCMojo<O> extends AbstractXJCMojo<O> {
 
 	private static final String JAXB_NSURI = "https://jakarta.ee/xml/ns/jaxb";
 
 	public static final String ADD_IF_EXISTS_TO_EPISODE_SCHEMA_BINDINGS_TRANSFORMATION_RESOURCE_NAME = "/"
-			+ RawXJC2Mojo.class.getPackage().getName().replace('.', '/') + "/addIfExistsToEpisodeSchemaBindings.xslt";
+			+ RawXJCMojo.class.getPackage().getName().replace('.', '/') + "/addIfExistsToEpisodeSchemaBindings.xslt";
 
 	private Collection<Artifact> xjcPluginArtifacts;
 

--- a/maven-plugin/plugin-core/src/test/java/org/jvnet/jaxb/maven/RawXJCMojoTest.java
+++ b/maven-plugin/plugin-core/src/test/java/org/jvnet/jaxb/maven/RawXJCMojoTest.java
@@ -24,7 +24,7 @@ import java.util.jar.JarOutputStream;
 
 import static org.junit.Assert.assertEquals;
 
-public class RawXJC2MojoTest {
+public class RawXJCMojoTest {
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -50,7 +50,7 @@ public class RawXJC2MojoTest {
     public void collectBindingUrisFromDependencies() throws Exception {
         List<URI> bindings = new ArrayList<>();
 
-        final RawXJC2Mojo<Void> mojo = new RawXJC2Mojo<Void>() {
+        final RawXJCMojo<Void> mojo = new RawXJCMojo<Void>() {
 
             @Override
             public MavenProject getProject() {
@@ -106,7 +106,7 @@ public class RawXJC2MojoTest {
     public void collectsBindingUrisFromArtifact() throws Exception {
         List<URI> bindings = new ArrayList<>();
 
-        final RawXJC2Mojo<Void> mojo = new RawXJC2Mojo<Void>() {
+        final RawXJCMojo<Void> mojo = new RawXJCMojo<Void>() {
 
 			@Override
 			protected IOptionsFactory<Void> getOptionsFactory() {

--- a/maven-plugin/plugin-core/src/test/java/org/jvnet/jaxb/maven/tests/AddIfExistsToEpisodeSchemaBindingsTest.java
+++ b/maven-plugin/plugin-core/src/test/java/org/jvnet/jaxb/maven/tests/AddIfExistsToEpisodeSchemaBindingsTest.java
@@ -5,14 +5,14 @@ import java.io.InputStream;
 import org.codehaus.plexus.util.IOUtil;
 import org.junit.Assert;
 import org.junit.Test;
-import org.jvnet.jaxb.maven.RawXJC2Mojo;
+import org.jvnet.jaxb.maven.RawXJCMojo;
 
 public class AddIfExistsToEpisodeSchemaBindingsTest {
 
 	@Test
 	public void transformationResourceIsAccessible() {
-		InputStream is = RawXJC2Mojo.class
-				.getResourceAsStream(RawXJC2Mojo.ADD_IF_EXISTS_TO_EPISODE_SCHEMA_BINDINGS_TRANSFORMATION_RESOURCE_NAME);
+		InputStream is = RawXJCMojo.class
+				.getResourceAsStream(RawXJCMojo.ADD_IF_EXISTS_TO_EPISODE_SCHEMA_BINDINGS_TRANSFORMATION_RESOURCE_NAME);
 		Assert.assertNotNull(is);
 		IOUtil.close(is);
 	}

--- a/maven-plugin/plugin/src/main/java/org/jvnet/jaxb/maven/XJCMojo.java
+++ b/maven-plugin/plugin/src/main/java/org/jvnet/jaxb/maven/XJCMojo.java
@@ -20,12 +20,12 @@ import com.sun.tools.xjc.model.Model;
 import com.sun.tools.xjc.outline.Outline;
 
 /**
- * JAXB 2.x Mojo.
+ * JAXB Mojo.
  *
  * @author Aleksei Valikov (valikov@gmx.net)
  */
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE, requiresDependencyCollection = ResolutionScope.COMPILE, threadSafe = true)
-public class XJC2Mojo extends RawXJC2Mojo<Options> {
+public class XJCMojo extends RawXJCMojo<Options> {
 
 	private final IOptionsFactory<Options> optionsFactory = new OptionsFactory();
 

--- a/maven-plugin/plugin/src/main/java/org/jvnet/jaxb/maven/XJCTestMojo.java
+++ b/maven-plugin/plugin/src/main/java/org/jvnet/jaxb/maven/XJCTestMojo.java
@@ -8,14 +8,14 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import java.io.File;
 
 /**
- * JAXB 2.x Test Mojo.
+ * JAXB Test Mojo.
  *
  * Generates sources for testing purpose (ie in /target/generated-test-sources/xjc path).
  *
  * @author Aleksei Valikov (valikov@gmx.net)
  */
 @Mojo(name = "generate-test", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, requiresDependencyResolution = ResolutionScope.TEST, requiresDependencyCollection = ResolutionScope.TEST, threadSafe = true)
-public class XJC2TestMojo extends XJC2Mojo {
+public class XJCTestMojo extends XJCMojo {
 
     /**
      * <p>

--- a/maven-plugin/plugin/src/test/java/org/jvnet/jaxb/maven/JAXBGenerateTest.java
+++ b/maven-plugin/plugin/src/test/java/org/jvnet/jaxb/maven/JAXBGenerateTest.java
@@ -67,7 +67,7 @@ public abstract class JAXBGenerateTest extends AbstractMojoTestCase {
 		final MavenProject mavenProject = mavenProjectBuilder.build(pom, localRepository, null);
 
 
-		final XJC2Mojo generator = (XJC2Mojo) lookupMojo("generate", pom);
+		final XJCMojo generator = (XJCMojo) lookupMojo("generate", pom);
 		generator.setProject(mavenProject);
 		generator.setLocalRepository(localRepository);
 		generator.setSchemaDirectory(new File(getBaseDir(),"src/test/resources/"));

--- a/maven-plugin/testing/src/main/java/org/jvnet/jaxb/maven/test/RunXJCMojo.java
+++ b/maven-plugin/testing/src/main/java/org/jvnet/jaxb/maven/test/RunXJCMojo.java
@@ -8,8 +8,8 @@ import junit.framework.TestCase;
 
 import org.apache.maven.plugin.Mojo;
 import org.apache.maven.project.MavenProject;
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.XJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.XJCMojo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,11 +21,11 @@ import com.sun.tools.xjc.Options;
  * @author Aleksei Valikov
  */
 
-public class RunXJC2Mojo extends TestCase {
+public class RunXJCMojo extends TestCase {
 	/**
 	 * Logger.
 	 */
-	protected Logger log = LoggerFactory.getLogger(RunXJC2Mojo.class);
+	protected Logger log = LoggerFactory.getLogger(RunXJCMojo.class);
 
 	public void testExecute() throws Exception {
 		final Mojo mojo = initMojo();
@@ -65,17 +65,17 @@ public class RunXJC2Mojo extends TestCase {
 		return true;
 	}
 
-	public AbstractXJC2Mojo<Options> initMojo() {
-		final AbstractXJC2Mojo<Options> mojo = createMojo();
+	public AbstractXJCMojo<Options> initMojo() {
+		final AbstractXJCMojo<Options> mojo = createMojo();
 		configureMojo(mojo);
 		return mojo;
 	}
 
-	protected AbstractXJC2Mojo<Options> createMojo() {
-		return new XJC2Mojo();
+	protected AbstractXJCMojo<Options> createMojo() {
+		return new XJCMojo();
 	}
 
-	protected void configureMojo(final AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(final AbstractXJCMojo<Options> mojo) {
 		mojo.setProject(new MavenProject());
 		mojo.setSchemaDirectory(getSchemaDirectory());
 		mojo.setGenerateDirectory(getGeneratedDirectory());

--- a/maven-plugin/testing/src/test/java/org/jvnet/jaxb/maven/test/plugin/foo/tests/RunFooPlugin.java
+++ b/maven-plugin/testing/src/test/java/org/jvnet/jaxb/maven/test/plugin/foo/tests/RunFooPlugin.java
@@ -4,9 +4,9 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
-public class RunFooPlugin extends RunXJC2Mojo {
+public class RunFooPlugin extends RunXJCMojo {
 
 	@Override
 	public File getSchemaDirectory() {

--- a/maven-plugin/tests/JAXB-1044/src/test/java/org/jvnet/jaxb/maven/tests/JAXB_1044/RunJAXB_1044Mojo.java
+++ b/maven-plugin/tests/JAXB-1044/src/test/java/org/jvnet/jaxb/maven/tests/JAXB_1044/RunJAXB_1044Mojo.java
@@ -2,16 +2,16 @@ package org.jvnet.jaxb.maven.tests.JAXB_1044;
 
 import java.io.File;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
 import org.jvnet.jaxb.maven.ResourceEntry;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunJAXB_1044Mojo extends RunXJC2Mojo {
+public class RunJAXB_1044Mojo extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 
 		final ResourceEntry a_xsd = new ResourceEntry();

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-53/b/src/test/java/org/jvnet/jaxb/maven/tests/MAVEN_JAXB2_PLUGIN_53/b/RunMAVEN_JAXB2_PLUGIN_53Mojo.java
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-53/b/src/test/java/org/jvnet/jaxb/maven/tests/MAVEN_JAXB2_PLUGIN_53/b/RunMAVEN_JAXB2_PLUGIN_53Mojo.java
@@ -2,15 +2,15 @@ package org.jvnet.jaxb.maven.tests.MAVEN_JAXB2_PLUGIN_53.b;
 
 import java.io.File;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunMAVEN_JAXB2_PLUGIN_53Mojo extends RunXJC2Mojo {
+public class RunMAVEN_JAXB2_PLUGIN_53Mojo extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 		mojo.setCatalog(new File(getBaseDir(), "src/main/resources/catalog.cat"));
 		mojo.setUseDependenciesAsEpisodes(true);

--- a/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-77/service/src/test/java/org/jvnet/jaxb/maven/tests/MAVEN_JAXB2_PLUGIN_77/RunMAVEN_JAXB2_PLUGIN_77Mojo.java
+++ b/maven-plugin/tests/MAVEN_JAXB2_PLUGIN-77/service/src/test/java/org/jvnet/jaxb/maven/tests/MAVEN_JAXB2_PLUGIN_77/RunMAVEN_JAXB2_PLUGIN_77Mojo.java
@@ -2,15 +2,15 @@ package org.jvnet.jaxb.maven.tests.MAVEN_JAXB2_PLUGIN_77;
 
 import java.io.File;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunMAVEN_JAXB2_PLUGIN_77Mojo extends RunXJC2Mojo {
+public class RunMAVEN_JAXB2_PLUGIN_77Mojo extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 
 		mojo.setSchemaDirectory(new File(getBaseDir(), "src/main/resources/META-INF/project/schemas"));

--- a/maven-plugin/tests/catalog-xml/src/test/java/org/jvnet/jaxb/maven/tests/catalog/RunCatalogMojo.java
+++ b/maven-plugin/tests/catalog-xml/src/test/java/org/jvnet/jaxb/maven/tests/catalog/RunCatalogMojo.java
@@ -2,16 +2,16 @@ package org.jvnet.jaxb.maven.tests.catalog;
 
 import java.io.File;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
 import org.jvnet.jaxb.maven.resolver.tools.ClasspathCatalogResolver;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunCatalogMojo extends RunXJC2Mojo {
+public class RunCatalogMojo extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 
 		mojo

--- a/maven-plugin/tests/catalog-xml/src/test/java/org/jvnet/jaxb/maven/tests/catalog/RunPlainCatalogMojo.java
+++ b/maven-plugin/tests/catalog-xml/src/test/java/org/jvnet/jaxb/maven/tests/catalog/RunPlainCatalogMojo.java
@@ -2,15 +2,15 @@ package org.jvnet.jaxb.maven.tests.catalog;
 
 import java.io.File;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunPlainCatalogMojo extends RunXJC2Mojo {
+public class RunPlainCatalogMojo extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 
 		mojo

--- a/maven-plugin/tests/catalog/src/test/java/org/jvnet/jaxb/maven/tests/catalog/RunCatalogMojo.java
+++ b/maven-plugin/tests/catalog/src/test/java/org/jvnet/jaxb/maven/tests/catalog/RunCatalogMojo.java
@@ -2,16 +2,16 @@ package org.jvnet.jaxb.maven.tests.catalog;
 
 import java.io.File;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
 import org.jvnet.jaxb.maven.resolver.tools.ClasspathCatalogResolver;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunCatalogMojo extends RunXJC2Mojo {
+public class RunCatalogMojo extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 
 		mojo

--- a/maven-plugin/tests/catalog/src/test/java/org/jvnet/jaxb/maven/tests/catalog/RunPlainCatalogMojo.java
+++ b/maven-plugin/tests/catalog/src/test/java/org/jvnet/jaxb/maven/tests/catalog/RunPlainCatalogMojo.java
@@ -2,15 +2,15 @@ package org.jvnet.jaxb.maven.tests.catalog;
 
 import java.io.File;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunPlainCatalogMojo extends RunXJC2Mojo {
+public class RunPlainCatalogMojo extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 
 		mojo

--- a/maven-plugin/tests/p_o/src/test/java/org/jvnet/mjiip/tests/p_o/RunP_OPlugin.java
+++ b/maven-plugin/tests/p_o/src/test/java/org/jvnet/mjiip/tests/p_o/RunP_OPlugin.java
@@ -1,14 +1,14 @@
 package org.jvnet.mjiip.tests.p_o;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunP_OPlugin extends RunXJC2Mojo {
+public class RunP_OPlugin extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 //		mojo.setExtension(true);
 //		mojo.setForceRegenerate(true);

--- a/maven-plugin/tests/res/src/test/java/org/jvnet/jaxb/maven/tests/res/RunResMojo.java
+++ b/maven-plugin/tests/res/src/test/java/org/jvnet/jaxb/maven/tests/res/RunResMojo.java
@@ -2,17 +2,17 @@ package org.jvnet.jaxb.maven.tests.res;
 
 import java.io.File;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
 import org.jvnet.jaxb.maven.DependencyResource;
 import org.jvnet.jaxb.maven.ResourceEntry;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.Options;
 
-public class RunResMojo extends RunXJC2Mojo {
+public class RunResMojo extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo<Options> mojo) {
+	protected void configureMojo(AbstractXJCMojo<Options> mojo) {
 		super.configureMojo(mojo);
 
 		mojo.setCatalog(new File(getBaseDir(),"src/main/jaxb/catalog.cat"));

--- a/maven-plugin/tests/rnc/src/test/java/org/jvnet/jaxb/maven/tests/rnc/RunRNCMojo.java
+++ b/maven-plugin/tests/rnc/src/test/java/org/jvnet/jaxb/maven/tests/rnc/RunRNCMojo.java
@@ -1,14 +1,14 @@
 package org.jvnet.jaxb.maven.tests.rnc;
 
-import org.jvnet.jaxb.maven.AbstractXJC2Mojo;
-import org.jvnet.jaxb.maven.test.RunXJC2Mojo;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
 
 import com.sun.tools.xjc.reader.Ring;
 
-public class RunRNCMojo extends RunXJC2Mojo {
+public class RunRNCMojo extends RunXJCMojo {
 
 	@Override
-	protected void configureMojo(AbstractXJC2Mojo mojo) {
+	protected void configureMojo(AbstractXJCMojo mojo) {
 		super.configureMojo(mojo);
 
 		// final ResourceEntry a_xsd = new ResourceEntry();

--- a/pom.xml
+++ b/pom.xml
@@ -65,10 +65,7 @@
 
     <!-- Dependencies versions -->
     <ant.version>1.10.12</ant.version>
-    <dtd-parser.version>1.4.5</dtd-parser.version>
-    <!-- jakarta.activation.version>1.2.2</jakarta.activation.version -->
     <jaxb.version>3.0.2</jaxb.version>
-    <istack.version>4.0.1</istack.version>
 
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-io.version>2.11.0</commons-io.version>
@@ -233,38 +230,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.glassfish.jaxb</groupId>
-        <artifactId>jaxb-bom</artifactId>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-bom-ext</artifactId>
         <version>${jaxb.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <!--
-      <dependency>
-        <groupId>com.sun.xml.bind.external</groupId>
-        <artifactId>rngom</artifactId>
-        <version>${jaxb.version}</version>
-      </dependency>
-      -->
-      <dependency>
-        <groupId>com.sun.xml.dtd-parser</groupId>
-        <artifactId>dtd-parser</artifactId>
-        <version>${dtd-parser.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.sun.istack</groupId>
-        <artifactId>istack-commons-tools</artifactId>
-        <version>${istack.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun</groupId>
-            <artifactId>tools</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <!-- End of jaxb-xjc dependencies -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,7 @@
         <version>${project.version}</version>
       </dependency>
 
-      <!-- JAXB2 Basics -->
+      <!-- JAXB Basics -->
       <dependency>
         <groupId>org.jvnet.jaxb</groupId>
         <artifactId>jaxb2-basics</artifactId>


### PR DESCRIPTION
Fixes #389 by moving to jaxb-bom-ext artifact
Partial fix for #378 to rename classes by removing the '2' part of JAXB / XJC