### PR TITLE
[#438] get version of XJC at runtime and dump it on source generation

### DIFF
--- a/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/AbstractXJCMojo.java
+++ b/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/AbstractXJCMojo.java
@@ -41,6 +41,14 @@ import org.sonatype.plexus.build.incremental.DefaultBuildContext;
 public abstract class AbstractXJCMojo<O> extends AbstractMojo implements
 		DependencyResourceResolver {
 
+    /**
+     * This method should be overriden in extending classes to get real value
+     * @return currently running XJC version
+     */
+    public XJCVersion getVersion() {
+        return XJCVersion.UNDEFINED;
+    }
+
 	@Parameter(defaultValue = "${settings}", readonly = true)
 	private Settings settings;
 

--- a/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/RawXJCMojo.java
+++ b/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/RawXJCMojo.java
@@ -95,13 +95,23 @@ public abstract class RawXJCMojo<O> extends AbstractXJCMojo<O> {
 	public static final String ADD_IF_EXISTS_TO_EPISODE_SCHEMA_BINDINGS_TRANSFORMATION_RESOURCE_NAME = "/"
 			+ RawXJCMojo.class.getPackage().getName().replace('.', '/') + "/addIfExistsToEpisodeSchemaBindings.xslt";
 
+    private final XJCVersion version;
+
 	private Collection<Artifact> xjcPluginArtifacts;
 
 	private Collection<File> xjcPluginFiles;
 
 	private List<URL> xjcPluginURLs;
 
-	public Collection<Artifact> getXjcPluginArtifacts() {
+    public RawXJCMojo(XJCVersion version) {
+        this.version = version;
+    }
+
+    public XJCVersion getVersion() {
+        return version;
+    }
+
+    public Collection<Artifact> getXjcPluginArtifacts() {
 		return xjcPluginArtifacts;
 	}
 
@@ -469,9 +479,9 @@ public abstract class RawXJCMojo<O> extends AbstractXJCMojo<O> {
 			} else {
 				final boolean isUpToDate = isUpToDate();
 				if (!isUpToDate) {
-					getLog().info("Sources are not up-to-date, XJC will be executed.");
+					getLog().info("Sources are not up-to-date, XJC (version " + getVersion().getRaw() + ") will be executed.");
 				} else {
-					getLog().info("Sources are up-to-date, XJC will be skipped.");
+					getLog().info("Sources are up-to-date, XJC (version " + getVersion().getRaw() + ") will be skipped.");
 					return;
 				}
 			}

--- a/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/XJCVersion.java
+++ b/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/XJCVersion.java
@@ -1,0 +1,61 @@
+package org.jvnet.jaxb.maven;
+
+public class XJCVersion {
+    public static final XJCVersion UNDEFINED = new XJCVersion(null);
+    private String raw = "UNDEFINED";
+    private int major;
+    private int minor;
+    private int bugfix;
+
+    public XJCVersion(String version) {
+        if (version != null) {
+            this.raw = version;
+            int indexOfSnapshot = version.indexOf("-SNAPSHOT");
+            if (indexOfSnapshot >= 0) {
+                version = version.substring(0, indexOfSnapshot);
+            }
+            String[] split = version.split("\\.");
+            if (split.length >= 3) {
+                major = Integer.valueOf(split[0]);
+                minor = Integer.valueOf(split[1]);
+                bugfix = Integer.valueOf(split[2]);
+            }
+        }
+    }
+
+    public String getRaw() {
+        return raw;
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+
+    public int getBugfix() {
+        return bugfix;
+    }
+
+    public boolean isKnown() {
+        return !(this.major == 0 && this.minor == 0 && this.bugfix == 0);
+    }
+
+    public boolean gte(int major, int minor, int bugfix) {
+        return this.major > major || (this.major == major && this.minor > minor) || (this.major == major && this.minor == minor && this.bugfix >= bugfix);
+    }
+
+    public boolean gt(int major, int minor, int bugfix) {
+        return this.major > major || (this.major == major && this.minor > minor) || (this.major == major && this.minor == minor && this.bugfix > bugfix);
+    }
+
+    public boolean lte(int major, int minor, int bugfix) {
+        return this.major < major || (this.major == major && this.minor < minor) || (this.major == major && this.minor == minor && this.bugfix <= bugfix);
+    }
+
+    public boolean lt(int major, int minor, int bugfix) {
+        return this.major < major || (this.major == major && this.minor < minor) || (this.major == major && this.minor == minor && this.bugfix < bugfix);
+    }
+}

--- a/maven-plugin/plugin-core/src/test/java/org/jvnet/jaxb/maven/RawXJCMojoTest.java
+++ b/maven-plugin/plugin-core/src/test/java/org/jvnet/jaxb/maven/RawXJCMojoTest.java
@@ -50,7 +50,7 @@ public class RawXJCMojoTest {
     public void collectBindingUrisFromDependencies() throws Exception {
         List<URI> bindings = new ArrayList<>();
 
-        final RawXJCMojo<Void> mojo = new RawXJCMojo<Void>() {
+        final RawXJCMojo<Void> mojo = new RawXJCMojo<>(XJCVersion.UNDEFINED) {
 
             @Override
             public MavenProject getProject() {
@@ -106,7 +106,7 @@ public class RawXJCMojoTest {
     public void collectsBindingUrisFromArtifact() throws Exception {
         List<URI> bindings = new ArrayList<>();
 
-        final RawXJCMojo<Void> mojo = new RawXJCMojo<Void>() {
+        final RawXJCMojo<Void> mojo = new RawXJCMojo<Void>(XJCVersion.UNDEFINED) {
 
 			@Override
 			protected IOptionsFactory<Void> getOptionsFactory() {

--- a/maven-plugin/plugin/src/main/java/org/jvnet/jaxb/maven/XJCMojo.java
+++ b/maven-plugin/plugin/src/main/java/org/jvnet/jaxb/maven/XJCMojo.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Iterator;
 
+import com.sun.tools.xjc.Messages;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -29,7 +30,15 @@ public class XJCMojo extends RawXJCMojo<Options> {
 
 	private final IOptionsFactory<Options> optionsFactory = new OptionsFactory();
 
-	@Override
+    public XJCMojo() {
+        super(parseXJCVersion());
+    }
+
+    private static XJCVersion parseXJCVersion() {
+        return new XJCVersion(Messages.format("Driver.BuildID"));
+    }
+
+    @Override
 	protected IOptionsFactory<Options> getOptionsFactory() {
 		return optionsFactory;
 	}


### PR DESCRIPTION
Fixes #438 