### PR TITLE
[#375] Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ please file it [on their project page](https://github.com/mojohaus/jaxb2-maven-p
 JAXB Plugins (former JAXB Basics) is an [open source](https://github.com/highsource/jaxb-tools/blob/master/LICENSE) project
 which provides useful plugins and tools for [JAXB 4.x reference implementation](https://github.com/eclipse-ee4j/jaxb-ri/tree/4.0.2-RI).
 
+For the current version 4.X and the previous version 3.X, its artifacts are named `org.jvnet.jaxb:jaxb-plugins`, while the previous verions 2.X were named `org.jvnet.jaxb:jaxb2-basics`. So, please replace all "jaxb2-basics" with "jaxb-plugins" in the following documentations (also in wiki) if you use versions 3.X and 4.X.
+
 ## Documentation
 
 Please refer to the [wiki](https://github.com/highsource/jaxb-tools/wiki/JAXB2-Basic) for documentation.


### PR DESCRIPTION
Clarify the name difference between `jaxb2-basics` in versions 2.X and `jaxb-plugins` in versions 3.X and 4.X.

In issue #375, many codes were updated to change from `jaxb2-basics` to `jaxb-plugins`, but the docs are left out-of-date. I think at least the README should have a clarification for this change.

Here's the situation for new user like me:
- I read "JAXB Plugins (former JAXB Basics)" and thought "OK, so now it's called JAXB Plugins". But right below it there are subtitles called "Using JAXB Basics" and "JAXB Basics Plugins"... I was confused and thought "OK, It's name 'Basics' there is to distinguish from the main Maven plugin, huh!"
- Then throughout the docs, I only saw `jaxb2-basics` in the example codes, which lead me to search for "jaxb2-basics" on Maven Central. I only saw versions 2.X but thought "The Basics Plugins are not said to have the same version as the main Maven Plugin, hence the latest version is OK!"
- I ran `xjc` with `-classpath` to `org.jvnet.jaxb:jaxb2-basics` and got error.