### PR TITLE
[#334] upgrade to maven-3 apis and set maven-minimal version to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ The project is currently containing the following tools :
 Please check our [Migration Guide](https://github.com/highsource/jaxb-tools/wiki/JAXB-Tools-Migration-Guide) for any questions about migrating
 from previous releases to newers one.
 
+## Maven versions
+Starting from 4.0.1, this plugin requires maven 3.1.0 as minimal version.
+
+If you still need maven 2.x or maven 3.0.x, you can still use the previous released versions
+but you should consider upgrading maven to at least 3.1.0.
+
 ## Java versions
 
 This project supports Java 11 and higher.

--- a/hyperjaxb/ejb/tests/episodes/b/src/test/java/org/jvnet/hyperjaxb3/ejb/tests/episodes/b/tests/RunEpisodesBPlugin.java
+++ b/hyperjaxb/ejb/tests/episodes/b/src/test/java/org/jvnet/hyperjaxb3/ejb/tests/episodes/b/tests/RunEpisodesBPlugin.java
@@ -8,6 +8,9 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.DefaultArtifactRepository;
 import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -95,7 +98,10 @@ public class RunEpisodesBPlugin extends AbstractMojoTestCase {
 		mojo.setRemoveOldOutput(true);
 
 		mojo.setProject(mavenProject);
-		mojo.setLocalRepository(localRepository);
+        MavenExecutionRequest request = new DefaultMavenExecutionRequest();
+        request.setLocalRepository(localRepository);
+        final MavenSession mavenSession = new MavenSession(null, null, request, null);
+		mojo.setMavenSession(mavenSession);
 		mojo.setExtension(true);
 		mojo.setDebug(false);
 		// mojo.setSchemaLanguage("XMLSCHEMA");

--- a/hyperjaxb/maven/plugin/pom.xml
+++ b/hyperjaxb/maven/plugin/pom.xml
@@ -10,6 +10,9 @@
 	<packaging>maven-plugin</packaging>
 	<name>JAXB Tools :: Hyperjaxb3 :: Maven :: Plugin</name>
 
+  <prerequisites>
+    <maven>${maven.minimal.version}</maven>
+  </prerequisites>
 	<dependencies>
 		<dependency>
 			<groupId>org.jvnet.jaxb</groupId>
@@ -19,10 +22,20 @@
 			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb-maven-plugin</artifactId>
 		</dependency>
+    <!-- Maven plugin and api classes -->
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-artifact</artifactId>
-			<version>${maven.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/maven-plugin/plugin-core/pom.xml
+++ b/maven-plugin/plugin-core/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
+      <artifactId>maven-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/RawXJCMojo.java
+++ b/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/RawXJCMojo.java
@@ -49,10 +49,8 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
-import org.apache.maven.artifact.resolver.filter.AndArtifactFilter;
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
-import org.apache.maven.artifact.resolver.filter.TypeArtifactFilter;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Resource;
@@ -395,8 +393,8 @@ public abstract class RawXJCMojo<O> extends AbstractXJCMojo<O> {
 	protected void resolveXJCPluginArtifacts()
 			throws ArtifactResolutionException, ArtifactNotFoundException, InvalidDependencyVersionException {
 
-		this.xjcPluginArtifacts = ArtifactUtils.resolveTransitively(getArtifactFactory(), getArtifactResolver(),
-				getLocalRepository(), getArtifactMetadataSource(), getPlugins(), getProject());
+		this.xjcPluginArtifacts = ArtifactUtils.resolveTransitively(getArtifactFactory(), getRepositorySystem(),
+				getMavenSession().getLocalRepository(), getArtifactMetadataSource(), getPlugins(), getProject());
 		this.xjcPluginFiles = ArtifactUtils.getFiles(this.xjcPluginArtifacts);
 		this.xjcPluginURLs = CollectionUtils.apply(this.xjcPluginFiles, IOUtils.GET_URL);
 	}
@@ -406,7 +404,7 @@ public abstract class RawXJCMojo<O> extends AbstractXJCMojo<O> {
 		this.episodeArtifacts = new LinkedHashSet<Artifact>();
 		{
 			final Collection<Artifact> episodeArtifacts = ArtifactUtils.resolve(getArtifactFactory(),
-					getArtifactResolver(), getLocalRepository(), getArtifactMetadataSource(), getEpisodes(),
+					getRepositorySystem(), getMavenSession().getLocalRepository(), getArtifactMetadataSource(), getEpisodes(),
 					getProject());
 			this.episodeArtifacts.addAll(episodeArtifacts);
 		}
@@ -414,11 +412,9 @@ public abstract class RawXJCMojo<O> extends AbstractXJCMojo<O> {
 			if (getUseDependenciesAsEpisodes()) {
 				@SuppressWarnings("unchecked")
 				final Collection<Artifact> projectArtifacts = getProject().getArtifacts();
-				final AndArtifactFilter filter = new AndArtifactFilter();
-				filter.add(new ScopeArtifactFilter(DefaultArtifact.SCOPE_COMPILE));
-				filter.add(new TypeArtifactFilter("jar"));
+				final ArtifactFilter filter = new ScopeArtifactFilter(DefaultArtifact.SCOPE_COMPILE);
 				for (Artifact artifact : projectArtifacts) {
-					if (filter.include(artifact)) {
+					if (filter.include(artifact) && "jar".equals(artifact.getType())) {
 						this.episodeArtifacts.add(artifact);
 					}
 				}
@@ -798,9 +794,8 @@ public abstract class RawXJCMojo<O> extends AbstractXJCMojo<O> {
 		final Collection<Artifact> projectArtifacts = getProject().getArtifacts();
 		final List<Artifact> compileScopeArtifacts = new ArrayList<Artifact>(projectArtifacts.size());
 		final ArtifactFilter scopeFilter = new ScopeArtifactFilter(DefaultArtifact.SCOPE_COMPILE);
-		final ArtifactFilter typeFilter = new TypeArtifactFilter("pom");
 		for (Artifact artifact : projectArtifacts) {
-			if (scopeFilter.include(artifact) && !typeFilter.include(artifact)) {
+			if (scopeFilter.include(artifact) && !"pom".equals(artifact.getType())) {
 				compileScopeArtifacts.add(artifact);
 			}
 		}

--- a/maven-plugin/plugin/pom.xml
+++ b/maven-plugin/plugin/pom.xml
@@ -10,7 +10,7 @@
     <version>4.0.1-SNAPSHOT</version>
   </parent>
   <prerequisites>
-    <maven>${maven.version}</maven>
+    <maven>${maven.minimal.version}</maven>
   </prerequisites>
   <dependencies>
     <dependency>
@@ -46,7 +46,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
+      <artifactId>maven-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/maven-plugin/plugin/src/test/java/org/jvnet/jaxb/maven/JAXBGenerateTest.java
+++ b/maven-plugin/plugin/src/test/java/org/jvnet/jaxb/maven/JAXBGenerateTest.java
@@ -17,12 +17,16 @@ package org.jvnet.jaxb.maven;
 import java.io.File;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.repository.DefaultArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
+import org.apache.maven.artifact.repository.MavenArtifactRepository;
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.MavenProjectBuilder;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingResult;
 
 public abstract class JAXBGenerateTest extends AbstractMojoTestCase {
 
@@ -30,13 +34,13 @@ public abstract class JAXBGenerateTest extends AbstractMojoTestCase {
 		System.setProperty("basedir", getBaseDir().getAbsolutePath());
 	}
 
-	protected MavenProjectBuilder mavenProjectBuilder;
+	protected ProjectBuilder mavenProjectBuilder;
 
 	protected void setUp() throws Exception {
 		super.setUp();
 
-		mavenProjectBuilder = (MavenProjectBuilder) getContainer().lookup(
-				MavenProjectBuilder.ROLE);
+		mavenProjectBuilder = (ProjectBuilder) getContainer().lookup(
+            ProjectBuilder.class);
 	}
 
 	protected static File getBaseDir() {
@@ -59,17 +63,22 @@ public abstract class JAXBGenerateTest extends AbstractMojoTestCase {
 		final File pom = new File(getBaseDir(),
 		"src/test/resources/test-pom.xml");
 
-        final ArtifactRepository localRepository = new DefaultArtifactRepository( "local",
+        final ArtifactRepository localRepository = new MavenArtifactRepository( "local",
+            new File(getBaseDir(), "target/test-repository").toURI().toURL().toString(),
+            new DefaultRepositoryLayout(),
+            new ArtifactRepositoryPolicy(),
+            new ArtifactRepositoryPolicy());
 
-        		new File(getBaseDir(), "target/test-repository").toURI().toURL().toString()        		, new DefaultRepositoryLayout());
+        MavenExecutionRequest request = new DefaultMavenExecutionRequest();
+        request.setLocalRepository(localRepository);
+        final MavenSession mavenSession = new MavenSession(null, null, request, null);
 
-
-		final MavenProject mavenProject = mavenProjectBuilder.build(pom, localRepository, null);
+		final ProjectBuildingResult mavenProject = mavenProjectBuilder.build(pom, null);
 
 
 		final XJCMojo generator = (XJCMojo) lookupMojo("generate", pom);
-		generator.setProject(mavenProject);
-		generator.setLocalRepository(localRepository);
+        generator.setMavenSession(mavenSession);
+		generator.setProject(mavenProject.getProject());
 		generator.setSchemaDirectory(new File(getBaseDir(),"src/test/resources/"));
 		generator.setSchemaIncludes(new String[] { "*.xsd" });
 		generator.setBindingIncludes(new String[] { "*.xjb" });

--- a/maven-plugin/testing/pom.xml
+++ b/maven-plugin/testing/pom.xml
@@ -30,7 +30,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
+      <artifactId>maven-core</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/maven-plugin/testing/src/main/java/org/jvnet/jaxb/maven/test/RunXJCMojo.java
+++ b/maven-plugin/testing/src/main/java/org/jvnet/jaxb/maven/test/RunXJCMojo.java
@@ -6,6 +6,9 @@ import java.util.List;
 
 import junit.framework.TestCase;
 
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.Mojo;
 import org.apache.maven.project.MavenProject;
 import org.jvnet.jaxb.maven.AbstractXJCMojo;
@@ -77,6 +80,9 @@ public class RunXJCMojo extends TestCase {
 
 	protected void configureMojo(final AbstractXJCMojo<Options> mojo) {
 		mojo.setProject(new MavenProject());
+        MavenExecutionRequest request = new DefaultMavenExecutionRequest();
+        MavenSession mavenSession = new MavenSession(null, null, request, null);
+        mojo.setMavenSession(mavenSession);
 		mojo.setSchemaDirectory(getSchemaDirectory());
 		mojo.setGenerateDirectory(getGeneratedDirectory());
 		mojo.setGeneratePackage(getGeneratePackage());

--- a/pom.xml
+++ b/pom.xml
@@ -46,9 +46,6 @@
       </roles>
     </developer>
   </developers>
-  <prerequisites>
-    <maven>3.1</maven>
-  </prerequisites>
   <modules>
     <module>jaxb-bom-parent</module>
     <module>jaxb-annotate-parent</module>
@@ -59,8 +56,14 @@
   </modules>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.version>2.0.9</maven.version>
     <jdk.version>11</jdk.version>
+
+    <!-- used by maven-plugin prerequisites -->
+    <maven.minimal.version>3.1.0</maven.minimal.version>
+    <!-- maven api properties (overriden in check-maven-prerequisites profile -->
+    <maven.version>3.8.8</maven.version>
+    <maven-plugin-annotations.version>3.8.2</maven-plugin-annotations.version>
+    <maven.plugin.testing.version>3.3.0</maven.plugin.testing.version>
 
     <!-- Dependencies versions -->
     <ant.version>1.10.12</ant.version>
@@ -79,8 +82,7 @@
     <plexus-utils.version>3.5.1</plexus-utils.version>
 
     <!-- Maven plugin versions -->
-    <maven.plugin.testing.version>2.1</maven.plugin.testing.version>
-    <maven.plugin.plugin.version>3.7.1</maven.plugin.plugin.version>
+    <maven.plugin.plugin.version>3.10.2</maven.plugin.plugin.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
     <maven-clean-plugin.version>3.3.1</maven-clean-plugin.version>
@@ -209,6 +211,14 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>check-maven-prerequisites</id>
+      <properties>
+        <maven.version>3.1.0</maven.version>
+        <maven-plugin-annotations.version>3.1</maven-plugin-annotations.version>
+        <maven.plugin.testing.version>3.1.0</maven.plugin.testing.version>
+      </properties>
+    </profile>
   </profiles>
   <distributionManagement>
     <snapshotRepository>
@@ -263,22 +273,12 @@
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
-        <artifactId>maven-project</artifactId>
-        <version>${maven.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
         <artifactId>maven-model</artifactId>
         <version>${maven.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-core</artifactId>
-        <version>${maven.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-artifact-manager</artifactId>
         <version>${maven.version}</version>
       </dependency>
       <dependency>
@@ -290,7 +290,7 @@
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
-        <version>${maven.plugin.plugin.version}</version>
+        <version>${maven-plugin-annotations.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugin-testing</groupId>


### PR DESCRIPTION
Fixes #334 
Fixes #459 

Move to maven-3 apis and set maven dependencies to high number to avoid CVE
Add new profile `check-maven-prerequisites` to check build against the minimal maven-version supported in `prerequisites` tags -> @mattrpav please upgrade github-workflow to add a build with this profile.
Will close #305 PR since upgrade done here.
No `maven-compat` module used here, so it's fully compatible with maven3 and drops support of maven2.
Doing this should make this plugin compatible with maven4