### PR TITLE
[#468] update maven surefire / failsafe plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,8 @@
     <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
     <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-    <maven-surefire-plugin.version>3.0.0-M8</maven-surefire-plugin.version>
-    <maven-failsafe-plugin.version>3.1.2</maven-failsafe-plugin.version>
+    <maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>3.2.3</maven-failsafe-plugin.version>
     <cxf.version>4.0.3</cxf.version>
     <cxf-xjc-runtime.version>4.0.0</cxf-xjc-runtime.version>
     <cxf-codegen-plugin.version>4.0.2</cxf-codegen-plugin.version>


### PR DESCRIPTION
Fixes #468 

Move to latest available version of maven-surefire and maven-failsafe plugins (3.2.3)