### PR TITLE
[#457] add multiple namespaces prefix bindings

### DIFF
--- a/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/namespace_prefix/NamespacePrefixPlugin.java
+++ b/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/namespace_prefix/NamespacePrefixPlugin.java
@@ -186,26 +186,39 @@ public class NamespacePrefixPlugin extends Plugin {
                 continue;
             }
 
+
             // get the prefix's name
             String prefix = "";
             for (BIDeclaration declaration : b.getDecls()) {
+                // get targeted prefix and targeted NS
+                String targetedPrefix = "";
+                String targetedNS = "";
                 if (declaration instanceof BIXPluginCustomization) {
                     final BIXPluginCustomization customization = (BIXPluginCustomization) declaration;
                     if (customization.element.getNamespaceURI().equals(Customizations.NAMESPACE_URI)) {
                         if (!customization.element.getLocalName().equals(Customizations.PREFIX_NAME)) {
                             throw new RuntimeException("Unrecognized element [" + customization.element.getLocalName() + "]");
                         }
-                        prefix = customization.element.getAttribute("name");
+                        targetedPrefix = customization.element.getAttribute("name");
+                        targetedNS = customization.element.getAttribute("namespaceURI");
                         customization.markAsAcknowledged();
-                        break;
                     } else if (customization.element.getNamespaceURI().equals(LegacyCustomizations.NAMESPACE_URI)) {
                         if (!customization.element.getLocalName().equals(LegacyCustomizations.PREFIX_NAME)) {
                             throw new RuntimeException("Unrecognized element [" + customization.element.getLocalName() + "]");
                         }
                         logger.warn("Please migrate your namespace in xsd / xjb from " + LegacyCustomizations.NAMESPACE_URI + " to " + Customizations.NAMESPACE_URI);
-                        prefix = customization.element.getAttribute("name");
+                        targetedPrefix = customization.element.getAttribute("name");
+                        targetedNS = customization.element.getAttribute("namespaceURI");
                         customization.markAsAcknowledged();
-                        break;
+                    }
+                }
+
+                if (targetedPrefix != null && !"".equals(targetedPrefix)) {
+                    if (targetedNS != null && !"".equals(targetedNS) && !targetedNS.equals(targetNS)) {
+                        list.add(new Pair(targetedNS, targetedPrefix));
+                    } else if ("".equals(prefix)) {
+                        // only take first binding as actual true binding for current targetNS (break condition used before in for loop)
+                        prefix = targetedPrefix;
                     }
                 }
             }

--- a/jaxb-plugins-parent/tests/namespace/src/main/resources/binding.xjb
+++ b/jaxb-plugins-parent/tests/namespace/src/main/resources/binding.xjb
@@ -4,7 +4,7 @@
   xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
   xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-  xmlns:namespace="http://jaxb2-commons.dev.java.net/basic/namespace-prefix"
+  xmlns:namespace="urn:jaxb.jvnet.org:plugin:namespace-prefix"
 
   jaxb:extensionBindingPrefixes="xjc">
 
@@ -22,6 +22,18 @@
 		</jaxb:schemaBindings>
 		<jaxb:bindings>
 			<namespace:prefix name="b" />
+      <namespace:prefix name="aprefix" namespaceURI="a" />
 		</jaxb:bindings>
 	</jaxb:bindings>
+  <jaxb:bindings schemaLocation="c.xsd">
+    <jaxb:schemaBindings>
+      <jaxb:package name="org.jvnet.jaxb.test.namespace.c" />
+    </jaxb:schemaBindings>
+    <jaxb:bindings>
+      <namespace:prefix name="creal" />
+      <namespace:prefix name="otherfake" />
+      <namespace:prefix name="aprefix" namespaceURI="a" />
+      <namespace:prefix name="bprefix" namespaceURI="b" />
+    </jaxb:bindings>
+  </jaxb:bindings>
 </jaxb:bindings>

--- a/jaxb-plugins-parent/tests/namespace/src/main/resources/c.xsd
+++ b/jaxb-plugins-parent/tests/namespace/src/main/resources/c.xsd
@@ -1,0 +1,47 @@
+<xsd:schema
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="c"
+	xmlns:a="a"
+	xmlns:c="c"
+	elementFormDefault="qualified">
+
+	<xsd:import namespace="a" schemaLocation="a.xsd"/>
+
+	<xsd:element name="c" type="c:CType"/>
+
+	<xsd:complexType name="CType">
+		<xsd:complexContent>
+		    <xsd:extension base="a:AType">
+				<xsd:sequence>
+					<xsd:element name="c" type="c:C1Type"/>
+					<xsd:element name="ca" type="a:AType" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+		    </xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="C1Type">
+		<xsd:complexContent>
+		    <xsd:extension base="a:A1Type">
+				<xsd:sequence>
+					<xsd:element name="c1" type="xsd:string"/>
+				</xsd:sequence>
+		    </xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="issueHJIII24Mammal">
+		<xsd:complexContent>
+		    <xsd:extension base="a:issueHJIII24Animal">
+		    </xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="issueHJIII24Dog">
+		<xsd:complexContent>
+		    <xsd:extension base="c:issueHJIII24Mammal">
+		    </xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/jaxb-plugins-parent/tests/namespace/src/test/java/org/jvnet/jaxb/tests/namespace/ATest.java
+++ b/jaxb-plugins-parent/tests/namespace/src/test/java/org/jvnet/jaxb/tests/namespace/ATest.java
@@ -1,0 +1,21 @@
+package org.jvnet.jaxb.tests.namespace;
+
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlSchema;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.jaxb.test.namespace.a.AType;
+
+public class ATest {
+
+    @Test
+    public void testA() {
+        AType a = new AType();
+        XmlSchema schema = a.getClass().getPackage().getAnnotation(XmlSchema.class);
+        XmlNs[] namespaces = schema.xmlns();
+        Assert.assertNotNull(namespaces);
+        Assert.assertEquals(1, namespaces.length);
+        Assert.assertEquals("a", namespaces[0].namespaceURI());
+        Assert.assertEquals("a", namespaces[0].prefix());
+    }
+}

--- a/jaxb-plugins-parent/tests/namespace/src/test/java/org/jvnet/jaxb/tests/namespace/BTest.java
+++ b/jaxb-plugins-parent/tests/namespace/src/test/java/org/jvnet/jaxb/tests/namespace/BTest.java
@@ -1,0 +1,29 @@
+package org.jvnet.jaxb.tests.namespace;
+
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlSchema;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.jaxb.test.namespace.b.BType;
+
+import java.util.Arrays;
+
+public class BTest {
+
+    @Test
+    public void testB() {
+        BType b = new BType();
+        XmlSchema schema = b.getClass().getPackage().getAnnotation(XmlSchema.class);
+        XmlNs[] namespaces = schema.xmlns();
+        Assert.assertNotNull(namespaces);
+        Assert.assertEquals(2, namespaces.length);
+        XmlNs aNs = Arrays.stream(namespaces).filter(ns -> "aprefix".equals(ns.prefix())).findFirst().orElse(null);
+        Assert.assertNotNull(aNs);
+        Assert.assertEquals("a", aNs.namespaceURI());
+        Assert.assertEquals("aprefix", aNs.prefix());
+        XmlNs bNs = Arrays.stream(namespaces).filter(ns -> "b".equals(ns.prefix())).findFirst().orElse(null);
+        Assert.assertNotNull(bNs);
+        Assert.assertEquals("b", bNs.namespaceURI());
+        Assert.assertEquals("b", bNs.prefix());
+    }
+}

--- a/jaxb-plugins-parent/tests/namespace/src/test/java/org/jvnet/jaxb/tests/namespace/CTest.java
+++ b/jaxb-plugins-parent/tests/namespace/src/test/java/org/jvnet/jaxb/tests/namespace/CTest.java
@@ -1,0 +1,57 @@
+package org.jvnet.jaxb.tests.namespace;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlSchema;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.jaxb.test.namespace.a.A1Type;
+import org.jvnet.jaxb.test.namespace.c.C1Type;
+import org.jvnet.jaxb.test.namespace.c.CType;
+
+import javax.xml.namespace.QName;
+import java.io.StringWriter;
+import java.util.Arrays;
+
+public class CTest {
+
+    @Test
+    public void testC() throws JAXBException {
+        CType c = new CType();
+        XmlSchema schema = c.getClass().getPackage().getAnnotation(XmlSchema.class);
+        XmlNs[] namespaces = schema.xmlns();
+        Assert.assertEquals(3, namespaces.length);
+        XmlNs aNs = Arrays.stream(namespaces).filter(ns -> "aprefix".equals(ns.prefix())).findFirst().orElse(null);
+        Assert.assertNotNull(aNs);
+        Assert.assertEquals("a", aNs.namespaceURI());
+        Assert.assertEquals("aprefix", aNs.prefix());
+        XmlNs bNs = Arrays.stream(namespaces).filter(ns -> "bprefix".equals(ns.prefix())).findFirst().orElse(null);
+        Assert.assertNotNull(bNs);
+        Assert.assertEquals("b", bNs.namespaceURI());
+        Assert.assertEquals("bprefix", bNs.prefix());
+        XmlNs cNs = Arrays.stream(namespaces).filter(ns -> "creal".equals(ns.prefix())).findFirst().orElse(null);
+        Assert.assertNotNull(cNs);
+        Assert.assertEquals("c", cNs.namespaceURI());
+        Assert.assertEquals("creal", cNs.prefix());
+
+        c.setA(new A1Type());
+        c.setC(new C1Type());
+
+        JAXBElement<CType> jaxbElement
+            = new JAXBElement<>( new QName("c", "cPart"), CType.class, c);
+        JAXBContext context = JAXBContext.newInstance(CType.class.getPackage().getName());
+        StringWriter writer = new StringWriter();
+        context.createMarshaller().marshal(jaxbElement, writer);
+        String marshalled = writer.toString();
+
+        Assert.assertNotNull(marshalled);
+        String expectedA = "xmlns:aprefix=\"a\"";
+        Assert.assertTrue(marshalled.contains(expectedA));
+        String expectedB = "xmlns:bprefix=\"b\"";
+        Assert.assertTrue(marshalled.contains(expectedB));
+        String expectedC = "xmlns:creal=\"c\"";
+        Assert.assertTrue(marshalled.contains(expectedC));
+    }
+}

--- a/jaxb-plugins-parent/tests/namespace/src/test/java/org/jvnet/jaxb/tests/namespace/RunNamespacePlugin.java
+++ b/jaxb-plugins-parent/tests/namespace/src/test/java/org/jvnet/jaxb/tests/namespace/RunNamespacePlugin.java
@@ -1,4 +1,4 @@
-package org.jvnet.jaxb2_commons.tests.namespace;
+package org.jvnet.jaxb.tests.namespace;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
Fixes #457 
Allow defining more than one prefix bindings with namespace-plugin
The plugin now reads the new `namespaceURI` attribute in binding configuration