### PR TITLE
[#487] move to slf4j-reload4j to remove log4j CVE

### DIFF
--- a/hyperjaxb/ejb/roundtrip/pom.xml
+++ b/hyperjaxb/ejb/roundtrip/pom.xml
@@ -52,7 +52,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<artifactId>slf4j-reload4j</artifactId>
 		</dependency>
 	</dependencies>
 	<build>

--- a/hyperjaxb/ejb/runtime/pom.xml
+++ b/hyperjaxb/ejb/runtime/pom.xml
@@ -21,8 +21,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-reload4j</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/hyperjaxb/ejb/samples/customerservice-cxf/pom.xml
+++ b/hyperjaxb/ejb/samples/customerservice-cxf/pom.xml
@@ -65,13 +65,8 @@
 		<!-- Logging -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<artifactId>slf4j-reload4j</artifactId>
 			<version>1.7.36</version>
-		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.12</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>

--- a/hyperjaxb/ejb/tests/ota/pom.xml
+++ b/hyperjaxb/ejb/tests/ota/pom.xml
@@ -40,7 +40,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<artifactId>slf4j-reload4j</artifactId>
 		</dependency>
 	</dependencies>
 	<build>

--- a/hyperjaxb/ejb/tutorials/po/step-one/pom.xml
+++ b/hyperjaxb/ejb/tutorials/po/step-one/pom.xml
@@ -46,7 +46,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<artifactId>slf4j-reload4j</artifactId>
 		</dependency>
 
 		<!-- Database -->

--- a/hyperjaxb/ejb/tutorials/po/step-three/pom.xml
+++ b/hyperjaxb/ejb/tutorials/po/step-three/pom.xml
@@ -46,7 +46,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<artifactId>slf4j-reload4j</artifactId>
 		</dependency>
 
 		<!-- Database -->

--- a/hyperjaxb/ejb/tutorials/po/step-two/pom.xml
+++ b/hyperjaxb/ejb/tutorials/po/step-two/pom.xml
@@ -47,7 +47,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<artifactId>slf4j-reload4j</artifactId>
 		</dependency>
 
 		<!-- Database -->

--- a/hyperjaxb/misc/jdo/roundtrip/pom.xml
+++ b/hyperjaxb/misc/jdo/roundtrip/pom.xml
@@ -32,11 +32,6 @@
 			<version>1.1</version>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.13</version>
-		</dependency>
-		<dependency>
 			<groupId>jpox</groupId>
 			<artifactId>jpox</artifactId>
 			<version>1.1.1</version>

--- a/hyperjaxb/misc/jdo/sample-hotel/pom.xml
+++ b/hyperjaxb/misc/jdo/sample-hotel/pom.xml
@@ -29,11 +29,6 @@
 			<version>1.1</version>
 		</dependency>
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.13</version>
-		</dependency>
-		<dependency>
 			<groupId>jpox</groupId>
 			<artifactId>jpox</artifactId>
 			<version>1.1.1</version>

--- a/hyperjaxb/pom.xml
+++ b/hyperjaxb/pom.xml
@@ -43,12 +43,6 @@
 				<artifactId>collections-generic</artifactId>
 				<version>4.01</version>
 			</dependency>
-			<!-- Log4j -->
-			<dependency>
-				<groupId>log4j</groupId>
-				<artifactId>log4j</artifactId>
-				<version>1.2.17</version>
-			</dependency>
 			<!-- SLF4J -->
 			<dependency>
 				<groupId>org.slf4j</groupId>
@@ -62,7 +56,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-log4j12</artifactId>
+				<artifactId>slf4j-reload4j</artifactId>
 				<version>1.7.36</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Fixes #487 

Remove log4j dependency and replace it with latest 1.x slf4j-reload4j to fix log4j CVE