### PR TITLE
[#481] move spring dep to only hyperjaxb, upgrade spring

### DIFF
--- a/hyperjaxb/ejb/plugin/pom.xml
+++ b/hyperjaxb/ejb/plugin/pom.xml
@@ -27,6 +27,14 @@
 			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>jaxb-plugins-tools</artifactId>
 		</dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
 		<dependency>
 			<groupId>org.jvnet.jaxb</groupId>
 			<artifactId>hyperjaxb3-ejb-roundtrip</artifactId>
@@ -62,17 +70,9 @@
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>xsom</artifactId>
 		</dependency>
-		<!--dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-annotations</artifactId>
-		</dependency-->
 		<dependency>
 			<groupId>jakarta.persistence</groupId>
 			<artifactId>jakarta.persistence-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring</artifactId>
 		</dependency>
 	</dependencies>
 	<build>

--- a/hyperjaxb/ejb/plugin/src/main/java/org/jvnet/jaxb/plugin/spring/AbstractSpringConfigurablePlugin.java
+++ b/hyperjaxb/ejb/plugin/src/main/java/org/jvnet/jaxb/plugin/spring/AbstractSpringConfigurablePlugin.java
@@ -1,5 +1,8 @@
 package org.jvnet.jaxb.plugin.spring;
 
+import com.sun.tools.xjc.BadCommandLineException;
+import com.sun.tools.xjc.Options;
+import com.sun.tools.xjc.outline.Outline;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -7,10 +10,6 @@ import org.jvnet.jaxb.plugin.AbstractParameterizablePlugin;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.FileSystemXmlApplicationContext;
-
-import com.sun.tools.xjc.BadCommandLineException;
-import com.sun.tools.xjc.Options;
-import com.sun.tools.xjc.outline.Outline;
 
 public abstract class AbstractSpringConfigurablePlugin extends
 		AbstractParameterizablePlugin {

--- a/hyperjaxb/ejb/samples/customerservice-cxf/pom.xml
+++ b/hyperjaxb/ejb/samples/customerservice-cxf/pom.xml
@@ -16,12 +16,12 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-orm</artifactId>
-			<version>3.0.1.RELEASE</version>
+			<version>6.1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>3.0.1.RELEASE</version>
+			<version>6.1.3</version>
 		</dependency>
 		<!-- Apache CXF -->
 		<dependency>
@@ -105,7 +105,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
-			<version>3.0.1.RELEASE</version>
+			<version>6.1.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/hyperjaxb/ejb/samples/customerservice-cxf/src/main/java/com/example/customerservice/service/CustomerServiceImpl.java
+++ b/hyperjaxb/ejb/samples/customerservice-cxf/src/main/java/com/example/customerservice/service/CustomerServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.customerservice.service;
 
-import org.springframework.orm.jpa.support.JpaDaoSupport;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,23 +11,24 @@ import com.example.customerservice.service.NoSuchCustomer;
 import com.example.customerservice.service.NoSuchCustomerException;
 
 @Transactional
-public class CustomerServiceImpl extends JpaDaoSupport implements
-		CustomerService {
+public class CustomerServiceImpl implements CustomerService {
+
+    @PersistenceContext
+    protected EntityManager theEntityManager;
 
 	@Transactional(propagation = Propagation.REQUIRED, readOnly = false)
 	public void deleteCustomerById(final Integer customerId)
 			throws NoSuchCustomerException {
 
 		final Customer customer = getCustomerById(customerId);
-		getJpaTemplate().remove(customer);
+		theEntityManager.remove(customer);
 	}
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Customer getCustomerById(final Integer customerId)
 			throws NoSuchCustomerException {
 
-		final Customer customer = getJpaTemplate().find(Customer.class,
-				customerId);
+		final Customer customer = theEntityManager.find(Customer.class, customerId);
 
 		if (customer == null) {
 			NoSuchCustomer noSuchCustomer = new NoSuchCustomer();
@@ -42,7 +44,7 @@ public class CustomerServiceImpl extends JpaDaoSupport implements
 
 	@Transactional(propagation = Propagation.REQUIRED, readOnly = false)
 	public Integer updateCustomer(Customer customer) {
-		final Customer mergedCustomer = getJpaTemplate().merge(customer);
+		final Customer mergedCustomer = theEntityManager.merge(customer);
 		return mergedCustomer.getCustomerId();
 	}
 

--- a/hyperjaxb/ejb/samples/pom.xml
+++ b/hyperjaxb/ejb/samples/pom.xml
@@ -18,9 +18,9 @@
 	</modules>
 	<profiles>
     <profile>
-      <id>jdk-11+</id>
+      <id>jdk-17+</id>
       <activation>
-        <jdk>[11,)</jdk>
+        <jdk>[17,)</jdk>
       </activation>
       <modules>
         <module>customerservice-cxf</module>

--- a/jaxb-plugins-parent/jaxb-plugins-tools/pom.xml
+++ b/jaxb-plugins-parent/jaxb-plugins-tools/pom.xml
@@ -44,10 +44,5 @@
       <artifactId>angus-activation</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring</artifactId>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
     <joda-time.version>2.5</joda-time.version>
     <junit4.version>4.13.2</junit4.version>
     <slf4j.version>1.7.36</slf4j.version>
+    <spring.version>5.3.31</spring.version>
     <stax-ex.version>1.8.3</stax-ex.version>
     <plexus-build-api.version>1.2.0</plexus-build-api.version>
     <plexus-utils.version>3.5.1</plexus-utils.version>
@@ -376,13 +377,17 @@
         <version>${slf4j.version}</version>
       </dependency>
 
-      <!-- Spring -->
+      <!-- Spring in Hibernate -->
       <dependency>
         <groupId>org.springframework</groupId>
-        <artifactId>spring</artifactId>
-        <version>2.0.7</version>
+        <artifactId>spring-context</artifactId>
+        <version>${spring.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-beans</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
       <!-- Hibernate -->
       <dependency>
         <groupId>org.hibernate</groupId>


### PR DESCRIPTION
Fixes #481

- Move spring dependency to hyperjaxb module only
- Upgrade spring to latest 5.x version (to keep jdk11 compatibility without breaking changes or dependencies on jakarta)