### PR TITLE
[#520] extends toStringPlugin to generate toString methods on enums

### DIFF
--- a/jaxb-plugins-parent/jaxb-plugins-runtime/src/main/java/org/jvnet/jaxb/lang/EnumToStringStrategy.java
+++ b/jaxb-plugins-parent/jaxb-plugins-runtime/src/main/java/org/jvnet/jaxb/lang/EnumToStringStrategy.java
@@ -1,0 +1,31 @@
+package org.jvnet.jaxb.lang;
+
+import org.jvnet.jaxb.locator.ObjectLocator;
+
+/**
+ * Original submission by Kevin Senechal (kevin.senechal@dooapp.com) on 30/07/15.
+ */
+public class EnumToStringStrategy extends JAXBToStringStrategy {
+
+    public StringBuilder appendStart(ObjectLocator parentLocator, Object parent, StringBuilder stringBuilder) {
+        if (parent instanceof Enum) {
+            return stringBuilder;
+        } else {
+            return super.appendStart(parentLocator, parent, stringBuilder);
+        }
+    }
+
+    public StringBuilder appendEnd(ObjectLocator parentLocator, Object parent, StringBuilder stringBuilder) {
+        if (parent instanceof Enum) {
+            return appendEnum((Enum) parent, stringBuilder);
+        } else {
+            return super.appendEnd(parentLocator, parent, stringBuilder);
+        }
+    }
+
+    protected StringBuilder appendEnum(Enum e, StringBuilder stringBuilder) {
+        stringBuilder.append(e.name());
+        return stringBuilder;
+    }
+
+}

--- a/jaxb-plugins-parent/tests/enumtostring/pom.xml
+++ b/jaxb-plugins-parent/tests/enumtostring/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jvnet.jaxb</groupId>
+    <artifactId>jaxb-plugins-tests</artifactId>
+    <version>4.0.6-SNAPSHOT</version>
+  </parent>
+  <artifactId>jaxb-plugins-test-enumtostring</artifactId>
+  <packaging>jar</packaging>
+  <name>JAXB Tools :: JAXB Plugins :: Test [enum-toString]</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.jvnet.jaxb</groupId>
+      <artifactId>jaxb-maven-plugin-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jvnet.jaxb</groupId>
+      <artifactId>jaxb-plugins-runtime</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <defaultGoal>test</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.jvnet.jaxb</groupId>
+        <artifactId>jaxb-maven-plugin</artifactId>
+        <configuration>
+          <extension>true</extension>
+          <args>
+            <arg>-XtoString</arg>
+            <arg>-XtoString-toStringStrategyClass=org.jvnet.jaxb.tests.enumtostring.MyEnumToStringStrategy</arg>
+            <arg>-XtoString-toStringEnums=true</arg>
+          </args>
+          <plugins>
+            <plugin>
+              <groupId>org.jvnet.jaxb</groupId>
+              <artifactId>jaxb-plugins</artifactId>
+            </plugin>
+          </plugins>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jaxb-plugins-parent/tests/enumtostring/src/main/java/org/jvnet/jaxb/tests/enumtostring/MyEnumToStringStrategy.java
+++ b/jaxb-plugins-parent/tests/enumtostring/src/main/java/org/jvnet/jaxb/tests/enumtostring/MyEnumToStringStrategy.java
@@ -1,0 +1,15 @@
+package org.jvnet.jaxb.tests.enumtostring;
+
+import generated.Model;
+import org.jvnet.jaxb.lang.EnumToStringStrategy;
+
+public class MyEnumToStringStrategy extends EnumToStringStrategy {
+    @Override
+    protected StringBuilder appendEnum(Enum e, StringBuilder stringBuilder) {
+        if (e instanceof Model) {
+            stringBuilder.append(((Model) e).value());
+            return stringBuilder;
+        }
+        return super.appendEnum(e, stringBuilder);
+    }
+}

--- a/jaxb-plugins-parent/tests/enumtostring/src/main/resources/sample.xsd
+++ b/jaxb-plugins-parent/tests/enumtostring/src/main/resources/sample.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="console">
+    <xs:complexType>
+      <xs:attribute name="model" type="model" use="required"/>
+      <xs:attribute name="vendor" type="vendor" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="model">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="PS3"/>
+      <xs:enumeration value="PS4"/>
+      <xs:enumeration value="PS5"/>
+      <xs:enumeration value="XBOX360"/>
+      <xs:enumeration value="XBOXONE"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="vendor">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="SONY"/>
+      <xs:enumeration value="MICROSOFT"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/jaxb-plugins-parent/tests/enumtostring/src/test/java/org/jvnet/jaxb/tests/enumtostring/ConsoleTest.java
+++ b/jaxb-plugins-parent/tests/enumtostring/src/test/java/org/jvnet/jaxb/tests/enumtostring/ConsoleTest.java
@@ -1,0 +1,33 @@
+package org.jvnet.jaxb.tests.enumtostring;
+
+import generated.Console;
+import generated.Model;
+import generated.Vendor;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConsoleTest {
+
+    @Test
+    public void testConsole() {
+        Console c = new Console();
+        c.setModel(Model.PS_5);
+        c.setVendor(Vendor.SONY);
+
+        String cToString = c.toString();
+        Assert.assertTrue(cToString.startsWith("generated.Console"));
+        Assert.assertTrue(cToString.endsWith("[model=PS5, vendor=SONY]"));
+    }
+
+    @Test
+    public void testModel() {
+        Model m = Model.PS_3;
+        Assert.assertEquals(Model.PS_3.value(), m.toString());
+    }
+
+    @Test
+    public void testVendor() {
+        Vendor v = Vendor.MICROSOFT;
+        Assert.assertEquals(Vendor.MICROSOFT.name(), v.toString());
+    }
+}

--- a/jaxb-plugins-parent/tests/enumtostring/src/test/resources/log4j.properties
+++ b/jaxb-plugins-parent/tests/enumtostring/src/test/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootCategory=DEBUG, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.target=system.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - <%m>%n

--- a/jaxb-plugins-parent/tests/pom.xml
+++ b/jaxb-plugins-parent/tests/pom.xml
@@ -19,6 +19,7 @@
     <module>commons_lang</module>
     <module>defaultvalue</module>
     <module>elementwrapper</module>
+    <module>enumtostring</module>
     <module>episodes</module>
     <module>fluentapi</module>
     <module>ignoring</module>


### PR DESCRIPTION
Fixes #520 

Add extra parameter `toStringEnums` with following usage `-XtoString-toStringEnums=true` to generate `toString` methods on enums.

This will allow someone to override the output of enums in custom strategy.
See example in `enumtostring` project in tests