### PR TITLE
[#533] add Automatic-Module-Name in jaxb-plugins-runtime

### DIFF
--- a/jaxb-plugins-parent/jaxb-plugins-runtime/pom.xml
+++ b/jaxb-plugins-parent/jaxb-plugins-runtime/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>org.eclipse.angus</groupId>
       <artifactId>angus-activation</artifactId>
-      <scope>provided</scope> 
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -54,6 +54,9 @@
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>org.jvnet.jaxb.plugins.runtime</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>


### PR DESCRIPTION
Fixes #533 

Adds the following entry in `MANIFEST.MF` of jaxb-plugins-runtime artifact :
> `Automatic-Module-Name: org.jvnet.jaxb.plugins.runtime`