### PR TITLE
[#465] create empty org.jvnet.jaxb2_commons:jaxb2-basics-runtime project

### DIFF
--- a/jaxb-plugins-parent/jaxb2-basics-runtime/pom.xml
+++ b/jaxb-plugins-parent/jaxb2-basics-runtime/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.jvnet.jaxb2_commons</groupId>
+  <artifactId>jaxb2-basics-runtime</artifactId>
+  <packaging>jar</packaging>
+  <name>JAXB Tools :: JAXB2 Basics :: Runtime [EMPTY]</name>
+  <description>
+    This is an empty jar to override
+    org.jvnet.jaxb2_commons:jaxb2-basics-runtime versions below v2
+    when you have both org.jvnet.jaxb2_commons:jaxb2-basics-runtime and
+    org.jvnet.jaxb:jaxb2-basics-runtime artifacts in the same application.
+    See https://github.com/highsource/jaxb-tools/issues/465
+  </description>
+  <parent>
+    <groupId>org.jvnet.jaxb</groupId>
+    <artifactId>jaxb-plugins-project</artifactId>
+    <version>4.0.7-SNAPSHOT</version>
+  </parent>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>empty-javadoc</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>javadoc</classifier>
+              <skipIfEmpty>false</skipIfEmpty>
+              <classesDirectory>${basedir}/src/main/javadoc</classesDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jaxb-plugins-parent/jaxb2-basics-runtime/src/main/javadoc/README.md
+++ b/jaxb-plugins-parent/jaxb2-basics-runtime/src/main/javadoc/README.md
@@ -1,0 +1,8 @@
+# Empty jaxb2-basics-runtime
+
+This is an empty jar to override
+`org.jvnet.jaxb2_commons:jaxb2-basics-runtime` versions below v2
+when you have both `org.jvnet.jaxb2_commons:jaxb2-basics-runtime` and
+`org.jvnet.jaxb:jaxb2-basics-runtime` artifacts in the same application.
+
+See https://github.com/highsource/jaxb-tools/issues/465

--- a/jaxb-plugins-parent/jaxb2-basics-runtime/src/main/resources/README.md
+++ b/jaxb-plugins-parent/jaxb2-basics-runtime/src/main/resources/README.md
@@ -1,0 +1,8 @@
+# Empty jaxb2-basics-runtime
+
+This is an empty jar to override
+`org.jvnet.jaxb2_commons:jaxb2-basics-runtime` versions below v2
+when you have both `org.jvnet.jaxb2_commons:jaxb2-basics-runtime` and
+`org.jvnet.jaxb:jaxb2-basics-runtime` artifacts in the same application.
+
+See https://github.com/highsource/jaxb-tools/issues/465

--- a/jaxb-plugins-parent/pom.xml
+++ b/jaxb-plugins-parent/pom.xml
@@ -11,6 +11,7 @@
   <name>JAXB Tools :: JAXB Plugins :: Project</name>
   <description>JAXB Plugins is a part of JAXB Tools project which implements plugins and tools for JAXB implementation.</description>
   <modules>
+    <module>jaxb2-basics-runtime</module>
     <module>jaxb-plugins-ant</module>
     <module>jaxb-plugins-runtime</module>
     <module>jaxb-plugins-tools</module>


### PR DESCRIPTION
First step to fix #465 with creation of empty project jar for `org.jvnet.jaxb2_commons:jaxb2-basics-runtime`