### PR TITLE
[#548] upgrade maven-bundle-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -674,7 +674,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>5.1.9</version>
         </plugin>
         <plugin>
           <groupId>org.ec4j.maven</groupId>


### PR DESCRIPTION
Fixes #548 

Upgrading `maven-bundle-plugin`

This will fix `MANIFEST.MF` generation from
```
Require-Capability: osgi.ee;filter:="(osgi.ee=UNKNOWN)"
```

to

```
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=11))"
```