### PR TITLE
[#560] add configuration for artifact exclusions in final classpath (which default to exclude xercesImpl and xml-apis artifacts)

### DIFF
--- a/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/AbstractXJCMojo.java
+++ b/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/AbstractXJCMojo.java
@@ -984,7 +984,27 @@ public abstract class AbstractXJCMojo<O> extends AbstractMojo implements
 		this.plugins = plugins;
 	}
 
-	@Component
+    /**
+     * <p>
+     * A list of artifacts to exclude from XJC Plugins resolveTransitively function.
+     * </p>
+     * <p>
+     * If you are using <code>xerces:xercesImpl</code> and / or <code>xml-apis</code>,
+     * adding them will exclude from the classpath resolution, fixing issue #560.
+     * </p>
+     */
+    @Parameter
+    private String[] artifactExcludes = new String[] {};
+
+    public String[] getArtifactExcludes() {
+        return artifactExcludes;
+    }
+
+    public void setArtifactExcludes(String[] artifactExcludes) {
+        this.artifactExcludes = artifactExcludes;
+    }
+
+    @Component
 	private RepositorySystem repositorySystem;
 
 	@Component
@@ -1123,6 +1143,7 @@ public abstract class AbstractXJCMojo<O> extends AbstractMojo implements
 						+ getScanDependenciesForBindings());
 		getLog().info("xjcPlugins:" + Arrays.toString(getPlugins()));
 		getLog().info("episodes:" + Arrays.toString(getEpisodes()));
+        getLog().info("artifactExcludes:" + Arrays.toString(getArtifactExcludes()));
 	}
 
 	private static final String XML_SCHEMA_CLASS_NAME = "XmlSchema";

--- a/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/RawXJCMojo.java
+++ b/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/RawXJCMojo.java
@@ -394,8 +394,10 @@ public abstract class RawXJCMojo<O> extends AbstractXJCMojo<O> {
 	protected void resolveXJCPluginArtifacts()
 			throws ArtifactResolutionException, ArtifactNotFoundException, InvalidDependencyVersionException {
 
-		this.xjcPluginArtifacts = ArtifactUtils.resolveTransitively(getArtifactFactory(), getRepositorySystem(),
-				getMavenSession().getLocalRepository(), getArtifactMetadataSource(), getPlugins(), getProject());
+		this.xjcPluginArtifacts = ArtifactUtils.resolveTransitively(
+            getArtifactFactory(), getRepositorySystem(),
+            getMavenSession().getLocalRepository(), getArtifactMetadataSource(),
+            getPlugins(), getProject(), getArtifactExcludes());
 		this.xjcPluginFiles = ArtifactUtils.getFiles(this.xjcPluginArtifacts);
 		this.xjcPluginURLs = CollectionUtils.apply(this.xjcPluginFiles, IOUtils.GET_URL);
 	}

--- a/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/util/ArtifactUtils.java
+++ b/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/util/ArtifactUtils.java
@@ -15,6 +15,7 @@ import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
 import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
+import org.apache.maven.artifact.resolver.filter.ExclusionSetFilter;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.artifact.InvalidDependencyVersionException;
@@ -27,13 +28,28 @@ public class ArtifactUtils {
 	private ArtifactUtils() {
 
 	}
+    public static Collection<Artifact> resolveTransitively(
+        final ArtifactFactory artifactFactory,
+        final RepositorySystem artifactResolver,
+        final ArtifactRepository localRepository,
+        final ArtifactMetadataSource artifactMetadataSource,
+        final Dependency[] dependencies, final MavenProject project)
+            throws InvalidDependencyVersionException,
+            ArtifactResolutionException, ArtifactNotFoundException {
+        return resolveTransitively(
+            artifactFactory, artifactResolver,
+            localRepository, artifactMetadataSource,
+            dependencies, project,
+            null);
+    }
 
 	public static Collection<Artifact> resolveTransitively(
 			final ArtifactFactory artifactFactory,
 			final RepositorySystem artifactResolver,
 			final ArtifactRepository localRepository,
 			final ArtifactMetadataSource artifactMetadataSource,
-			final Dependency[] dependencies, final MavenProject project)
+			final Dependency[] dependencies, final MavenProject project,
+            final String[] artifactExcludes)
 			throws InvalidDependencyVersionException,
 			ArtifactResolutionException, ArtifactNotFoundException {
 		if (dependencies == null) {
@@ -49,6 +65,10 @@ public class ArtifactUtils {
         request.setResolveRoot(false);
         request.setArtifact(project.getArtifact());
         request.setArtifactDependencies(artifacts);
+        if (artifactExcludes != null && artifactExcludes.length > 0) {
+            // remove dependencies from resolution
+            request.setCollectionFilter(new ExclusionSetFilter(artifactExcludes));
+        }
         request.setRemoteRepositories(project.getRemoteArtifactRepositories());
         request.setLocalRepository(localRepository);
 


### PR DESCRIPTION
Fixes #560 
This make `xercesImpl` and `xml-apis` doesnt come into final classpath of maven-plugin since they could conflict with other classes and fail generation