### PR TITLE
[#592] handle BigInteger / BigDecimal in default-value-plugin

### DIFF
--- a/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/defaultvalueplugin/DefaultValuePlugin.java
+++ b/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/defaultvalueplugin/DefaultValuePlugin.java
@@ -1,5 +1,7 @@
 package org.jvnet.jaxb.plugin.defaultvalueplugin;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Map;
 
 import javax.xml.datatype.DatatypeConfigurationException;
@@ -215,6 +217,24 @@ public class DefaultValuePlugin
                     var.init(JExpr.lit(Double.valueOf(defaultValue)));
                     if (opt.verbose)
                         System.out.println("[INFO] Initializing Double variable "
+                            +fieldInfo.displayName()
+                            +" to "+defaultValue+"");
+                }
+
+                else if ("java.math.BigInteger".equals(typeFullName)) {
+                    JClass biClass = co.implClass.owner().ref(BigInteger.class);
+                    var.init(JExpr._new(biClass).arg(JExpr.lit(defaultValue)));
+                    if (opt.verbose)
+                        System.out.println("[INFO] Initializing BigInteger variable "
+                            +fieldInfo.displayName()
+                            +" to "+defaultValue+"");
+                }
+
+                else if ("java.math.BigDecimal".equals(typeFullName)) {
+                    JClass bdClass = co.implClass.owner().ref(BigDecimal.class);
+                    var.init(JExpr._new(bdClass).arg(JExpr.lit(defaultValue)));
+                    if (opt.verbose)
+                        System.out.println("[INFO] Initializing BigDecimal variable "
                             +fieldInfo.displayName()
                             +" to "+defaultValue+"");
                 }

--- a/jaxb-plugins-parent/tests/defaultvalue/src/main/resources/Person.xsd
+++ b/jaxb-plugins-parent/tests/defaultvalue/src/main/resources/Person.xsd
@@ -27,4 +27,11 @@
   <xs:attribute name="house" type="xs:boolean" default="true" />
   <xs:attribute name="floor" type="xs:int" />
 </xs:complexType>
+
+<xs:complexType name="MathTypes">
+  <xs:sequence>
+    <xs:element name="bigint" type="xs:integer" default="1000" />
+    <xs:element name="bigdec" type="xs:decimal" default="1.0"/>
+  </xs:sequence>
+</xs:complexType>
 </xs:schema>

--- a/jaxb-plugins-parent/tests/defaultvalue/src/test/java/org/jvnet/jaxb2_commons/tests/defaultvalue/MathTypesTest.java
+++ b/jaxb-plugins-parent/tests/defaultvalue/src/test/java/org/jvnet/jaxb2_commons/tests/defaultvalue/MathTypesTest.java
@@ -1,0 +1,18 @@
+package org.jvnet.jaxb2_commons.tests.defaultvalue;
+
+import generated.MathTypes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class MathTypesTest {
+
+    @Test
+    public void testMathTypes() {
+        MathTypes m = new MathTypes();
+        Assertions.assertEquals(new BigInteger("1000"), m.getBigint());
+        Assertions.assertEquals(new BigDecimal("1.0"), m.getBigdec());
+    }
+}


### PR DESCRIPTION
Fixes #592 

Add `BigInteger` and `BigDecimal` to supported types for default-value-plugin