### PR TITLE
[#600] fix Time to Calendar conversion if in the past

### DIFF
--- a/hyperjaxb/ejb/runtime/src/main/java/org/jvnet/hyperjaxb3/xml/bind/annotation/adapters/XMLGregorianCalendarAsDateTime.java
+++ b/hyperjaxb/ejb/runtime/src/main/java/org/jvnet/hyperjaxb3/xml/bind/annotation/adapters/XMLGregorianCalendarAsDateTime.java
@@ -22,6 +22,6 @@ public class XMLGregorianCalendarAsDateTime extends
 		calendar.setHour(date.getHours());
 		calendar.setMinute(date.getMinutes());
 		calendar.setSecond(date.getSeconds());
-		calendar.setMillisecond((int) (date.getTime() % 1000));
+		calendar.setMillisecond(((int) (date.getTime() % 1000) + 1000) % 1000);
 	}
 }

--- a/hyperjaxb/ejb/runtime/src/main/java/org/jvnet/hyperjaxb3/xml/bind/annotation/adapters/XMLGregorianCalendarAsTime.java
+++ b/hyperjaxb/ejb/runtime/src/main/java/org/jvnet/hyperjaxb3/xml/bind/annotation/adapters/XMLGregorianCalendarAsTime.java
@@ -20,6 +20,6 @@ public class XMLGregorianCalendarAsTime extends
 		calendar.setHour(date.getHours());
 		calendar.setMinute(date.getMinutes());
 		calendar.setSecond(date.getSeconds());
-		calendar.setMillisecond((int) (date.getTime() % 1000));
+		calendar.setMillisecond(((int) (date.getTime() % 1000) + 1000) % 1000);
 	}
 }

--- a/hyperjaxb/ejb/runtime/src/test/java/org/jvnet/hyperjaxb3/xml/bind/annotation/adapters/XMLGregorianCalendarAsDateTimeTest.java
+++ b/hyperjaxb/ejb/runtime/src/test/java/org/jvnet/hyperjaxb3/xml/bind/annotation/adapters/XMLGregorianCalendarAsDateTimeTest.java
@@ -1,0 +1,29 @@
+package org.jvnet.hyperjaxb3.xml.bind.annotation.adapters;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.util.Date;
+
+public class XMLGregorianCalendarAsDateTimeTest {
+
+    @Test
+    public void testMarshal() throws Exception {
+        Date d = new Date(987 + 1000 * 3600 * 24 * 3);
+        XMLGregorianCalendarAsDateTime adapter = new XMLGregorianCalendarAsDateTime();
+        XMLGregorianCalendar c = adapter.marshal(d);
+
+        Assertions.assertEquals(987, c.getMillisecond());
+    }
+
+
+    @Test
+    public void testMarshalPast() throws Exception {
+        Date d = new Date(-987 - 1000 * 3600 * 24 * 3);
+        XMLGregorianCalendarAsDateTime adapter = new XMLGregorianCalendarAsDateTime();
+        XMLGregorianCalendar c = adapter.marshal(d);
+
+        Assertions.assertEquals(13, c.getMillisecond());
+    }
+}

--- a/hyperjaxb/ejb/runtime/src/test/java/org/jvnet/hyperjaxb3/xml/bind/annotation/adapters/XMLGregorianCalendarAsTimeTest.java
+++ b/hyperjaxb/ejb/runtime/src/test/java/org/jvnet/hyperjaxb3/xml/bind/annotation/adapters/XMLGregorianCalendarAsTimeTest.java
@@ -1,0 +1,29 @@
+package org.jvnet.hyperjaxb3.xml.bind.annotation.adapters;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.util.Date;
+
+public class XMLGregorianCalendarAsTimeTest {
+
+    @Test
+    public void testMarshal() throws Exception {
+        Date d = new Date(987 + 1000 * 3600 * 24 * 3);
+        XMLGregorianCalendarAsTime adapter = new XMLGregorianCalendarAsTime();
+        XMLGregorianCalendar c = adapter.marshal(d);
+
+        Assertions.assertEquals(987, c.getMillisecond());
+    }
+
+
+    @Test
+    public void testMarshalPast() throws Exception {
+        Date d = new Date(-987 - 1000 * 3600 * 24 * 3);
+        XMLGregorianCalendarAsTime adapter = new XMLGregorianCalendarAsTime();
+        XMLGregorianCalendar c = adapter.marshal(d);
+
+        Assertions.assertEquals(13, c.getMillisecond());
+    }
+}


### PR DESCRIPTION
Fixes #600 

If date is in the past (of epoch), getMillis return negative value, which ends in error