### PR TITLE
Add tests for #616 inject-listener-code plugin adds a PropertyChangeSupport field but no code to trigger the events in setters

### DIFF
--- a/jaxb-plugins-parent/tests/propertylistenerinjector/src/test/java/org/jvnet/jaxb/tests/propertylistenerinjector/AddressTest.java
+++ b/jaxb-plugins-parent/tests/propertylistenerinjector/src/test/java/org/jvnet/jaxb/tests/propertylistenerinjector/AddressTest.java
@@ -1,15 +1,26 @@
 package org.jvnet.jaxb.tests.propertylistenerinjector;
 
 import generated.Address;
+
+import java.beans.PropertyChangeEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class AddressTest {
 
     @Test
     public void testAddress() {
+        List<PropertyChangeEvent> events = new ArrayList<>();
+
         Address a = new Address();
-        // just checking new methods have been added
-        a.addPropertyChangeListener(null);
-        a.removePropertyChangeListener(null);
+        a.addPropertyChangeListener("street", events::add);
+        a.setStreet("Penny Lane");
+        Assertions.assertEquals(1, events.size());
+        PropertyChangeEvent e = events.get(0);
+        Assertions.assertEquals("Penny Lane", e.getNewValue());
+        Assertions.assertEquals("street", e.getPropertyName());
     }
 }


### PR DESCRIPTION
A test for #616