### PR TITLE
enable Reproducible Builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jdk.version>11</jdk.version>
+    <project.build.outputTimestamp>2025-08-10T19:28:00Z</project.build.outputTimestamp>
 
     <!-- used by maven-plugin prerequisites -->
     <maven.minimal.version>3.1.0</maven.minimal.version>
@@ -97,7 +98,7 @@
     <maven-nexus-staging-maven-plugin.version>1.6.8</maven-nexus-staging-maven-plugin.version>
     <maven-release-plugin.version>3.0.0-M7</maven-release-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
+    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>


### PR DESCRIPTION
minimum work done based on https://maven.apache.org/guides/mini/guide-reproducible-builds.html

this gives a good first step, even if not perfect as jaxb-tools uses jaxb-tools, that currently does not easily permit users to get reproducible generated content: see https://github.com/jvm-repo-rebuild/reproducible-central/issues/139 and #572 

so this implements first step of #642 

#572 will be also required to have jaxb-tools itself fully reproducible (or same workarounds as  https://github.com/apache/santuario-xml-security-java/blob/main/pom.xml#L399