### PR TITLE
Plugin to remove java bean methods for when you want to use Lombok or similar

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ JAXB Basics can only be used with JAXB/XJC 4.x.
 * [Xml ElementWrapper Plugin](https://github.com/highsource/jaxb-tools/wiki/JAXB-XML-ElementWrapper-Plugin) - generates `jakarta.xml.bind.annotation.XmlElementWrapper` annotation to simplify generated structure.
 * [Parent Pointer Plugin](https://github.com/highsource/jaxb-tools/wiki/JAXB-Parent-Pointer-Plugin) - generates getter in child elements to get the parent object (depends on `jaxb-plugins-runtime`)
 * [Property Listener Injector Plugin](https://github.com/highsource/jaxb-tools/wiki/JAXB-Property-Listener-Injector-Plugin) - adds methods in order to configure the generation of events on each `setXXX` method
+* [NoSetter Plugin](https://github.com/highsource/jaxb-tools/wiki/JAXB-NoBean-Plugin) - Removes setter methods (`setXXX`) from generated classes
+* [NoGetter Plugin](https://github.com/highsource/jaxb-tools/wiki/JAXB-NoBean-Plugin) - Removes getter methods (`getXXX` and `isXXX`) from generated classes
 
 ## Credits
 

--- a/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/nobean/NoGettersPlugin.java
+++ b/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/nobean/NoGettersPlugin.java
@@ -1,0 +1,44 @@
+package org.jvnet.jaxb.plugin.nobean;
+
+import com.sun.codemodel.JMethod;
+import com.sun.tools.xjc.Options;
+import com.sun.tools.xjc.Plugin;
+import com.sun.tools.xjc.outline.ClassOutline;
+import com.sun.tools.xjc.outline.Outline;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+
+import java.util.Collection;
+
+
+/**
+ * XJC plugin to remove getXX functions.
+ * The motivation is to allow for bean methods from annotations
+ *
+ * @author Asger Askov Blekinge "asga@kb.dk"
+ *
+ */
+public class NoGettersPlugin extends Plugin {
+
+    protected final String OPTION_NAME = "XnoGetters";
+
+    @Override
+    public String getOptionName() {
+        return OPTION_NAME;
+    }
+
+    @Override
+    public String getUsage() {
+        return "-" + OPTION_NAME + "    :   Do not generate getter methods for fields\n";
+    }
+
+    @Override
+    public boolean run(Outline model, Options opts, ErrorHandler errors) throws SAXException {
+        for (ClassOutline co : model.getClasses()) {
+            Collection<JMethod> methods = co.implClass.methods();
+            methods.removeIf(next -> next.name().startsWith("get"));
+            methods.removeIf(next -> next.name().startsWith("is"));
+        }
+        return true;
+    }
+}

--- a/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/nobean/NoSettersPlugin.java
+++ b/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/nobean/NoSettersPlugin.java
@@ -1,0 +1,43 @@
+package org.jvnet.jaxb.plugin.nobean;
+
+import com.sun.codemodel.JMethod;
+import com.sun.tools.xjc.Options;
+import com.sun.tools.xjc.Plugin;
+import com.sun.tools.xjc.outline.ClassOutline;
+import com.sun.tools.xjc.outline.Outline;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+
+import java.util.Collection;
+
+
+/**
+ * XJC plugin to remove setXX functions.
+ * The motivation is to allow for immutable objects or setters generated with Lombok annotations
+ *
+ * @author Asger Askov Blekinge "asga@kb.dk"
+ *
+ */
+public class NoSettersPlugin extends Plugin {
+
+    protected final String OPTION_NAME = "XnoSetters";
+
+    @Override
+    public String getOptionName() {
+        return OPTION_NAME;
+    }
+
+    @Override
+    public String getUsage() {
+        return "-" + OPTION_NAME + "    :   Do not generate setter methods for fields\n";
+    }
+
+    @Override
+    public boolean run(Outline model, Options opts, ErrorHandler errors) throws SAXException {
+        for (ClassOutline co : model.getClasses()) {
+            Collection<JMethod> methods = co.implClass.methods();
+            methods.removeIf(next -> next.name().startsWith("set"));
+        }
+        return true;
+    }
+}

--- a/jaxb-plugins-parent/jaxb-plugins/src/main/resources/META-INF/services/com.sun.tools.xjc.Plugin
+++ b/jaxb-plugins-parent/jaxb-plugins/src/main/resources/META-INF/services/com.sun.tools.xjc.Plugin
@@ -25,3 +25,5 @@ org.jvnet.jaxb.plugin.elementwrapper.XmlElementWrapperPlugin
 org.jvnet.jaxb.plugin.parentpointer.ParentPointerPlugin
 org.jvnet.jaxb.plugin.propertylistenerinjector.PropertyListenerInjectorPlugin
 org.jvnet.jaxb.plugin.map_init.MapInitPlugin
+org.jvnet.jaxb.plugin.nobean.NoSettersPlugin
+org.jvnet.jaxb.plugin.nobean.NoGettersPlugin

--- a/jaxb-plugins-parent/jaxb-plugins/src/test/java/org/jvnet/jaxb/plugin/nobean/tests/NoGettersPluginTest.java
+++ b/jaxb-plugins-parent/jaxb-plugins/src/test/java/org/jvnet/jaxb/plugin/nobean/tests/NoGettersPluginTest.java
@@ -1,0 +1,69 @@
+package org.jvnet.jaxb.plugin.nobean.tests;
+
+import com.sun.tools.xjc.Options;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class NoGettersPluginTest extends RunXJCMojo {
+
+    @Override
+    public File getSchemaDirectory() {
+        return new File(getBaseDir(), "src/test/resources");
+    }
+
+    @Override
+    protected void configureMojo(AbstractXJCMojo<Options> mojo) {
+        super.configureMojo(mojo);
+        mojo.setForceRegenerate(true);
+    }
+
+    @Override
+    public List<String> getArgs() {
+        final List<String> args = new ArrayList<>(super.getArgs());
+        args.add("-XnoGetters");
+        return args;
+    }
+
+    @Test
+    @Override
+    public void testExecute() throws Exception {
+        super.testExecute();
+
+        List<Path> javaFiles = listGeneratedFiles();
+
+        for (Path javaFile : javaFiles) {
+            List<String> lines = Files.readAllLines(javaFile);
+            for (int i = 0; i < lines.size(); i++) {
+                String line = lines.get(i);
+                if (line.matches("^ *public [a-zA-Z]+ (isSet|get)[A-Z]\\w+\\(\\) \\{")) {
+                    String fileLinePath = getGeneratedDirectory()
+                                              .toPath()
+                                              .relativize(javaFile)
+                                              .toString()
+                                              .replaceFirst(".java$", "")
+                                              .replaceAll("/", ".")
+                                          + "(" + javaFile.getFileName().toString() + ":" + i + ")";
+                    Assertions.fail("One getter remains in file " + fileLinePath + " in the line '" + line + "'");
+                }
+            }
+        }
+    }
+
+    private List<Path> listGeneratedFiles() throws IOException {
+        try (Stream<Path> list = Files.list(getGeneratedDirectory().toPath()
+                                                                   .resolve(Path.of("org/jvnet/jaxb/tests/one")));) {
+            return list.collect(Collectors.toList());
+        }
+    }
+}

--- a/jaxb-plugins-parent/jaxb-plugins/src/test/java/org/jvnet/jaxb/plugin/nobean/tests/NoSettersPluginTest.java
+++ b/jaxb-plugins-parent/jaxb-plugins/src/test/java/org/jvnet/jaxb/plugin/nobean/tests/NoSettersPluginTest.java
@@ -1,0 +1,68 @@
+package org.jvnet.jaxb.plugin.nobean.tests;
+
+import com.sun.tools.xjc.Options;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.jvnet.jaxb.maven.AbstractXJCMojo;
+import org.jvnet.jaxb.maven.test.RunXJCMojo;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class NoSettersPluginTest extends RunXJCMojo {
+
+    @Override
+    public File getSchemaDirectory() {
+        return new File(getBaseDir(), "src/test/resources");
+    }
+
+    @Override
+    protected void configureMojo(AbstractXJCMojo<Options> mojo) {
+        super.configureMojo(mojo);
+        mojo.setForceRegenerate(true);
+    }
+
+    @Override
+    public List<String> getArgs() {
+        final List<String> args = new ArrayList<>(super.getArgs());
+        args.add("-XnoGetters");
+        return args;
+    }
+    @Test
+    @Override
+    public void testExecute() throws Exception {
+        super.testExecute();
+
+        List<Path> javaFiles = listGeneratedFiles();
+
+        for (Path javaFile : javaFiles) {
+            List<String> lines = Files.readAllLines(javaFile);
+            for (int i = 0; i < lines.size(); i++) {
+                String line = lines.get(i);
+                if (line.matches("^ *public [a-zA-Z]+ (set)[A-Z]\\w+\\(\\) \\{")) {
+                    String fileLinePath = getGeneratedDirectory()
+                                              .toPath()
+                                              .relativize(javaFile)
+                                              .toString()
+                                              .replaceFirst(".java$", "")
+                                              .replaceAll("/", ".")
+                                          + "(" + javaFile.getFileName().toString() + ":" + i + ")";
+                    Assertions.fail("One set remains in file " + fileLinePath + " in the line '" + line + "'");
+                }
+            }
+        }
+    }
+
+    private List<Path> listGeneratedFiles() throws IOException {
+        try (Stream<Path> list = Files.list(getGeneratedDirectory().toPath()
+                                                                   .resolve(Path.of("org/jvnet/jaxb/tests/one")));) {
+            return list.collect(Collectors.toList());
+        }
+    }
+}


### PR DESCRIPTION
I wanted to use Lombok for the generated classes (via Annox)

`bindings.xjb`
```xml
<jaxb:bindings
    xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" xmlns:xs="http://www.w3.org/2001/XMLSchema"
    xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xmlns:annox="urn:jaxb.jvnet.org:annox"
    xsi:schemaLocation="https://jakarta.ee/xml/ns/jaxb https://jakarta.ee/xml/ns/jaxb/bindingschema_3_0.xsd"
    jaxb:extensionBindingPrefixes="xjc annox"
    version="3.0">
  <jaxb:bindings schemaLocation="scheam.xsd">
    <jaxb:bindings node="//xs:complexType" multiple="yes">
        <annox:annotateClass>@lombok.Data</annox:annotateClass>
        <annox:annotateClass>@lombok.With</annox:annotateClass>
        <annox:annotateClass>@lombok.AllArgsConstructor</annox:annotateClass>
        <annox:annotateClass>@lombok.NoArgsConstructor</annox:annotateClass>
    </jaxb:bindings>
  </jaxb:bindings>
</jaxb:bindings>
```

This worked, but the generated classes still contained jaxb-produced getter/setters methods. I wanted to be able to generate classes without these methods, so I made these two plugins noGetters and noSetters

