### PR TITLE
[#655] fix issue with faulty managed versions

### DIFF
--- a/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/util/ArtifactUtils.java
+++ b/maven-plugin/plugin-core/src/main/java/org/jvnet/jaxb/maven/util/ArtifactUtils.java
@@ -66,6 +66,7 @@ public class ArtifactUtils {
 
         ArtifactResolutionRequest request = new ArtifactResolutionRequest();
         request.setResolveTransitively(true);
+        request.setManagedVersionMap(Collections.emptyMap());
         request.setResolveRoot(false);
         request.setArtifact(project.getArtifact());
         request.setArtifactDependencies(artifacts);

--- a/maven-plugin/tests/episodes/c/pom.xml
+++ b/maven-plugin/tests/episodes/c/pom.xml
@@ -42,6 +42,13 @@
             </catalog>
           </catalogs>
           <useDependenciesAsEpisodes>true</useDependenciesAsEpisodes>
+          <plugins>
+            <plugin>
+              <groupId>org.jvnet.jaxb</groupId>
+              <artifactId>jaxb-plugins</artifactId>
+              <version>${project.version}</version>
+            </plugin>
+          </plugins>
         </configuration>
       </plugin>
     </plugins>

--- a/maven-plugin/tests/episodes/pom.xml
+++ b/maven-plugin/tests/episodes/pom.xml
@@ -16,6 +16,14 @@
     <module>d</module>
     <module>e</module>
   </modules>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>listenablefuture</artifactId>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>


### PR DESCRIPTION
Fixes #653
Fixes #655 

Make code actual as previous version with maven-compat in project
See full analysis in #655 [comment](https://github.com/highsource/jaxb-tools/issues/655#issuecomment-3557340787)