### PR TITLE
[#601] fix setTimezone in createCalendar of XMLGregorianCalendarAsDateTime

### DIFF
--- a/hyperjaxb/ejb/runtime/src/main/java/org/jvnet/hyperjaxb3/xml/bind/annotation/adapters/XMLGregorianCalendarAsDateTime.java
+++ b/hyperjaxb/ejb/runtime/src/main/java/org/jvnet/hyperjaxb3/xml/bind/annotation/adapters/XMLGregorianCalendarAsDateTime.java
@@ -23,5 +23,6 @@ public class XMLGregorianCalendarAsDateTime extends
 		calendar.setMinute(date.getMinutes());
 		calendar.setSecond(date.getSeconds());
 		calendar.setMillisecond(((int) (date.getTime() % 1000) + 1000) % 1000);
+        calendar.setTimezone(-date.getTimezoneOffset());
 	}
 }


### PR DESCRIPTION
Fixes #601 

Add support for Timezone in `createCalendar` function of `XMLGregorianCalendarAsDateTime` class
Tests are passing