### PR TITLE
[#689] Use 4.0.7 to fix https://github.com/eclipse-ee4j/jaxb-ri/pull1866

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
     <!-- Dependencies versions -->
     <ant.version>1.10.14</ant.version>
-    <jaxb.version>4.0.6</jaxb.version>
+    <jaxb.version>4.0.7</jaxb.version>
 
     <commons-beanutils.version>1.11.0</commons-beanutils.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
@@ -271,13 +271,6 @@
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-bom</artifactId>
-        <version>${jaxb.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-bom-ext</artifactId>
         <version>${jaxb.version}</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
Fix the encoded javadoc by using the newer jaxb (4.0.7), where this is fixed

See https://github.com/eclipse-ee4j/jaxb-ri/pull/1866