### PR TITLE
[#699] add otherAttributes if class has wildcard on plugins

### DIFF
--- a/jaxb-plugins-parent/jaxb-plugins-runtime/src/main/java/org/jvnet/jaxb/lang/JAXBMergeStrategy.java
+++ b/jaxb-plugins-parent/jaxb-plugins-runtime/src/main/java/org/jvnet/jaxb/lang/JAXBMergeStrategy.java
@@ -1,6 +1,11 @@
 package org.jvnet.jaxb.lang;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jvnet.jaxb.locator.ObjectLocator;
 
@@ -14,17 +19,46 @@ public class JAXBMergeStrategy extends DefaultMergeStrategy {
 			Collection leftCollection = (Collection) left;
 			@SuppressWarnings("rawtypes")
 			Collection rightCollection = (Collection) right;
-			return mergeInternal(leftLocator, rightLocator, leftCollection,
-					rightCollection);
-		} else {
+			return mergeInternal(leftLocator, rightLocator, leftCollection, rightCollection);
+		} else if (left instanceof Map && right instanceof Map) {
+            @SuppressWarnings("rawtypes")
+            Map leftMap = (Map) left;
+            @SuppressWarnings("rawtypes")
+            Map rightMap = (Map) right;
+            return mergeInternal(leftLocator, rightLocator, leftMap, rightMap);
+        } else {
 			return super.mergeInternal(leftLocator, rightLocator, left, right);
 		}
 	}
 
+    protected Object mergeInternal(ObjectLocator leftLocator,
+                                   ObjectLocator rightLocator,
+                                   @SuppressWarnings("rawtypes") Map leftMap,
+                                   @SuppressWarnings("rawtypes") Map rightMap) {
+        if (leftMap == null && rightMap == null) {
+            return Collections.emptyMap();
+        }
+        @SuppressWarnings("rawtypes") Set<Map.Entry> leftMapEntrySet = leftMap == null ? ((Map) Collections.emptyMap()).entrySet() : leftMap.entrySet();
+        @SuppressWarnings("rawtypes") Set<Map.Entry> rightMapEntrySet = rightMap == null ? ((Map) Collections.emptyMap()).entrySet() : rightMap.entrySet();
+
+        return Stream.concat(leftMapEntrySet.stream(), rightMapEntrySet.stream()).collect(Collectors.toMap(
+                (v) -> v.getKey(),
+                (v) -> v.getValue(),
+                (value1, value2) -> value2 // En cas de doublon de clé, on garde la valeur de la map2
+            ));
+    }
+
 	protected Object mergeInternal(ObjectLocator leftLocator,
-			ObjectLocator rightLocator, @SuppressWarnings("rawtypes") Collection leftCollection,
-			@SuppressWarnings("rawtypes") Collection rightCollection) {
-		return !leftCollection.isEmpty() ? leftCollection : rightCollection;
+                                   ObjectLocator rightLocator,
+                                   @SuppressWarnings("rawtypes") Collection leftCollection,
+                                   @SuppressWarnings("rawtypes") Collection rightCollection) {
+        if (leftCollection == null && rightCollection == null) {
+            return Collections.emptyList();
+        }
+        return Stream.concat(
+                leftCollection == null ? Stream.empty() : leftCollection.stream(),
+                rightCollection == null ? Stream.empty() : rightCollection.stream())
+            .collect(Collectors.toList());
 	}
 
 	public static final JAXBMergeStrategy INSTANCE = new JAXBMergeStrategy();

--- a/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/copyable/CopyablePlugin.java
+++ b/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/copyable/CopyablePlugin.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 
 import javax.xml.namespace.QName;
 
-import com.sun.tools.xjc.model.CAttributePropertyInfo;
 import org.jvnet.jaxb.lang.CopyStrategy;
 import org.jvnet.jaxb.lang.CopyTo;
 import org.jvnet.jaxb.lang.JAXBCopyStrategy;
@@ -262,7 +261,7 @@ public class CopyablePlugin extends AbstractParameterizablePlugin {
 			final FieldOutline[] declaredFields = FieldOutlineUtils.filter(
 					classOutline.getDeclaredFields(), getIgnoring());
 
-			if (declaredFields.length > 0) {
+			if (declaredFields.length > 0 || classOutline.target.declaresAttributeWildcard()) {
 
 				final JBlock bl = body._if(draftCopy._instanceof(theClass))
 						._then();
@@ -343,6 +342,20 @@ public class CopyablePlugin extends AbstractParameterizablePlugin {
 
 					copyFieldAccessor.unsetValues(ifShouldBeUnsetBlock);
 				}
+
+                if (classOutline.target.declaresAttributeWildcard()) {
+                    final JBlock block = bl.block();
+
+                    final String name = FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME;
+                    final JType type = FieldOutlineUtils.getOtherAttributesType(codeModel);
+
+                    final JVar sourceField = block.decl(type, "source" + name,
+                        JExpr._this().invoke("get" + FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME));
+                    final JVar copyField = block.decl(type, "copy" + name,
+                        copy.invoke("get" + FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME));
+                    block.invoke(copyField, "clear");
+                    block.invoke(copyField, "putAll").arg(sourceField);
+                }
 			}
 
 			body._return(draftCopy);

--- a/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/equals/EqualsPlugin.java
+++ b/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/equals/EqualsPlugin.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 
 import javax.xml.namespace.QName;
 
+import com.sun.codemodel.JType;
 import org.jvnet.jaxb.lang.Equals;
 import org.jvnet.jaxb.lang.EqualsStrategy;
 import org.jvnet.jaxb.lang.JAXBEqualsStrategy;
@@ -188,10 +189,9 @@ public class EqualsPlugin extends AbstractParameterizablePlugin {
 
 			final JExpression _this = JExpr._this();
 
-			final FieldOutline[] declaredFields = FieldOutlineUtils.filter(
-					classOutline.getDeclaredFields(), getIgnoring());
+			final FieldOutline[] declaredFields = FieldOutlineUtils.filter(classOutline.getDeclaredFields(), getIgnoring());
 
-			if (declaredFields.length > 0) {
+			if (declaredFields.length > 0 || classOutline.target.declaresAttributeWildcard()) {
 
 				final JVar _that = body.decl(JMod.FINAL, theClass, "that",
 						JExpr.cast(theClass, object));
@@ -247,6 +247,38 @@ public class EqualsPlugin extends AbstractParameterizablePlugin {
 									.arg(rightFieldHasSetValue)))._then()
 							._return(JExpr.FALSE);
 				}
+
+                if (classOutline.target.declaresAttributeWildcard()) {
+                    final JBlock block = body.block();
+
+                    final String name = FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME;
+                    final JType type = FieldOutlineUtils.getOtherAttributesType(codeModel);
+
+                    final JVar lhsValue = block.decl(type, "lhs" + name,
+                        _this.invoke("get" + FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME));
+                    final JVar rhsValue = block.decl(type, "rhs" + name,
+                        _that.invoke("get" + FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME));
+
+                    final JExpression leftFieldLocator = codeModel
+                        .ref(LocatorUtils.class).staticInvoke("property")
+                        .arg(leftLocator)
+                        .arg(FieldOutlineUtils.OTHER_ATTRIBUTES_PRIVATE_NAME)
+                        .arg(lhsValue);
+                    final JExpression rightFieldLocator = codeModel
+                        .ref(LocatorUtils.class).staticInvoke("property")
+                        .arg(rightLocator)
+                        .arg(FieldOutlineUtils.OTHER_ATTRIBUTES_PRIVATE_NAME)
+                        .arg(rhsValue);
+                    block._if(
+                            JOp.not(JExpr.invoke(equalsStrategy, "equals")
+                                .arg(leftFieldLocator)
+                                .arg(rightFieldLocator)
+                                .arg(lhsValue)
+                                .arg(rhsValue)
+                                .arg(JExpr.TRUE)
+                                .arg(JExpr.TRUE)))._then()
+                        ._return(JExpr.FALSE);
+                }
 			}
 			body._return(JExpr.TRUE);
 		}

--- a/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/hashcode/HashCodePlugin.java
+++ b/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/hashcode/HashCodePlugin.java
@@ -217,6 +217,28 @@ public class HashCodePlugin extends AbstractParameterizablePlugin {
 									.arg(valueIsSet));
 				}
 			}
+
+            if (classOutline.target.declaresAttributeWildcard()) {
+                final JBlock block = body.block();
+
+                final JVar theValue = block.decl(FieldOutlineUtils.getOtherAttributesType(codeModel),
+                    "the" + FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME,
+                    JExpr._this().invoke("get" + FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME));
+
+                block.assign(
+                    currentHashCode,
+                    hashCodeStrategy
+                        .invoke("hashCode")
+                        .arg(codeModel
+                            .ref(LocatorUtils.class)
+                            .staticInvoke("property")
+                            .arg(locator)
+                            .arg(FieldOutlineUtils.OTHER_ATTRIBUTES_PRIVATE_NAME)
+                            .arg(theValue))
+                        .arg(currentHashCode).arg(theValue)
+                        .arg(JExpr.TRUE));
+            }
+
 			body._return(currentHashCode);
 		}
 		return hashCode$hashCode;

--- a/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/mergeable/MergeablePlugin.java
+++ b/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/mergeable/MergeablePlugin.java
@@ -194,7 +194,7 @@ public class MergeablePlugin extends AbstractParameterizablePlugin {
 			final FieldOutline[] declaredFields = FieldOutlineUtils.filter(
 					classOutline.getDeclaredFields(), getIgnoring());
 
-			if (declaredFields.length > 0) {
+			if (declaredFields.length > 0 || classOutline.target.declaresAttributeWildcard()) {
 
 				final JBlock body = methodBody._if(right._instanceof(theClass))
 						._then();
@@ -300,6 +300,43 @@ public class MergeablePlugin extends AbstractParameterizablePlugin {
 
 					targetFieldAccessor.unsetValues(ifShouldBeUnsetBlock);
 				}
+
+                if (classOutline.target.declaresAttributeWildcard()) {
+                    final JBlock block = body.block();
+
+                    final String name = FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME;
+                    final JType type = FieldOutlineUtils.getOtherAttributesType(codeModel);
+
+                    final JVar lhsValue = block.decl(type, "lhs" + name,
+                        leftObject.invoke("get" + FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME));
+                    final JVar rhsValue = block.decl(type, "rhs" + name,
+                        rightObject.invoke("get" + FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME));
+
+                    final JExpression leftFieldLocator = codeModel
+                        .ref(LocatorUtils.class).staticInvoke("property")
+                        .arg(leftLocator)
+                        .arg(FieldOutlineUtils.OTHER_ATTRIBUTES_PRIVATE_NAME)
+                        .arg(lhsValue);
+                    final JExpression rightFieldLocator = codeModel
+                        .ref(LocatorUtils.class).staticInvoke("property")
+                        .arg(rightLocator)
+                        .arg(FieldOutlineUtils.OTHER_ATTRIBUTES_PRIVATE_NAME)
+                        .arg(rhsValue);
+
+                    final JExpression mergedValue = JExpr.cast(
+                        type,
+                        mergeStrategy.invoke("merge")
+                            .arg(leftFieldLocator)
+                            .arg(rightFieldLocator)
+                            .arg(lhsValue)
+                            .arg(rhsValue)
+                            .arg(JExpr.TRUE)
+                            .arg(JExpr.TRUE));
+
+                    final JVar merged = block.decl(type, "merged" + name, target.invoke("get" + FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME));
+                    block.invoke(merged, "clear");
+                    block.invoke(merged, "putAll").arg(mergedValue);
+                }
 			}
 		}
 		return mergeFrom;

--- a/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/simpleequals/SimpleEqualsPlugin.java
+++ b/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/simpleequals/SimpleEqualsPlugin.java
@@ -1,6 +1,7 @@
 package org.jvnet.jaxb.plugin.simpleequals;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import javax.xml.namespace.QName;
 
@@ -77,7 +78,7 @@ public class SimpleEqualsPlugin extends
 		final FieldOutline[] fields = FieldOutlineUtils.filter(
 				classOutline.getDeclaredFields(), getIgnoring());
 
-		if (fields.length > 0) {
+		if (fields.length > 0 || classOutline.target.declaresAttributeWildcard()) {
 
 			final JVar _that = body.decl(JMod.FINAL, theClass, "that",
 					JExpr.cast(theClass, object));
@@ -133,6 +134,26 @@ public class SimpleEqualsPlugin extends
 						new EqualsArguments(codeModel, leftValue,
 								leftHasSetValue, rightValue, rightHasSetValue));
 			}
+
+            if (classOutline.target.declaresAttributeWildcard()) {
+                final JBlock block = body.block();
+
+                final String name = FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME;
+
+                final JType type = FieldOutlineUtils.getOtherAttributesType(codeModel);
+                final JVar leftValue = block.decl(type, "left" + name,
+                    _this.invoke("get" + FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME));
+                final JVar rightValue = block.decl(type, "left" + name,
+                    _that.invoke("get" + FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME));
+
+                getCodeGenerator().generate(
+                    block,
+                    type,
+                    Collections.emptyList(),
+                    true,
+                    new EqualsArguments(codeModel, leftValue,
+                        JExpr.TRUE, rightValue, JExpr.TRUE));
+            }
 		}
 		body._return(JExpr.TRUE);
 

--- a/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/simplehashcode/SimpleHashCodePlugin.java
+++ b/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/simplehashcode/SimpleHashCodePlugin.java
@@ -1,6 +1,7 @@
 package org.jvnet.jaxb.plugin.simplehashcode;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import javax.xml.namespace.QName;
 
@@ -34,8 +35,8 @@ public class SimpleHashCodePlugin extends
 
 	@Override
 	public String getUsage() {
-		return "  -XsimpleEquals :  Generate reflection-free runtime-free hashCode() methods.\n" +
-		       "                    See https://github.com/highsource/jaxb-tools/wiki/JAXB2-SimpleHashCode-Plugin";
+		return "  -XsimpleHashCode :  Generate reflection-free runtime-free hashCode() methods.\n" +
+		       "                      See https://github.com/highsource/jaxb-tools/wiki/JAXB2-SimpleHashCode-Plugin";
 	}
 
 	@Override
@@ -121,6 +122,25 @@ public class SimpleHashCodePlugin extends
 									getMultiplier(), value, hasSetValue));
 				}
 			}
+
+            if (classOutline.target.declaresAttributeWildcard()) {
+                final JBlock block = body.block();
+
+                block.assign(currentHashCode,
+                    currentHashCode.mul(JExpr.lit(getMultiplier())));
+                final JType exposedType = FieldOutlineUtils.getOtherAttributesType(codeModel);
+                final JVar value = block.decl(exposedType, "the" + FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME,
+                    JExpr._this().invoke("get" + FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME));
+
+                getCodeGenerator().generate(
+                    block,
+                    exposedType,
+                    Collections.emptyList(),
+                    true,
+                    new HashCodeArguments(codeModel, currentHashCode,
+                        getMultiplier(), value, JExpr.TRUE));
+            }
+
 			body._return(currentHashCode);
 		}
 	}

--- a/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/tostring/ToStringPlugin.java
+++ b/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/tostring/ToStringPlugin.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import javax.xml.namespace.QName;
 
 import com.sun.codemodel.JFieldVar;
+import com.sun.codemodel.JType;
 import com.sun.tools.xjc.outline.EnumOutline;
 import org.jvnet.jaxb.lang.JAXBToStringStrategy;
 import org.jvnet.jaxb.lang.ToString;
@@ -264,6 +265,20 @@ public class ToStringPlugin extends AbstractParameterizablePlugin {
 							.arg(valueIsSet);
 				}
 			}
+
+            if (classOutline.target.declaresAttributeWildcard()) {
+                final JBlock block = body.block();
+                final String name = FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME;
+                final JType type = FieldOutlineUtils.getOtherAttributesType(codeModel);
+
+                final JVar theValue = block.decl(type, "the" + name, JExpr._this().invoke("get" + FieldOutlineUtils.OTHER_ATTRIBUTES_PUBLIC_NAME));
+
+                block.invoke(toStringStrategy, "appendField")
+                    .arg(locator)
+                    .arg(JExpr._this())
+                    .arg(JExpr.lit(FieldOutlineUtils.OTHER_ATTRIBUTES_PRIVATE_NAME)).arg(buffer).arg(theValue)
+                    .arg(JExpr.TRUE);
+            }
 			body._return(buffer);
 		}
 		return toString$appendFields;

--- a/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/util/FieldOutlineUtils.java
+++ b/jaxb-plugins-parent/jaxb-plugins/src/main/java/org/jvnet/jaxb/plugin/util/FieldOutlineUtils.java
@@ -1,8 +1,13 @@
 package org.jvnet.jaxb.plugin.util;
 
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JType;
 import org.jvnet.jaxb.plugin.Ignoring;
 
 import com.sun.tools.xjc.outline.FieldOutline;
+
+import javax.xml.namespace.QName;
+import java.util.Map;
 
 public class FieldOutlineUtils {
 
@@ -10,13 +15,20 @@ public class FieldOutlineUtils {
 
 	}
 
+    public static String OTHER_ATTRIBUTES_PUBLIC_NAME = "OtherAttributes";
+    public static String OTHER_ATTRIBUTES_PRIVATE_NAME = "otherAttributes";
+
+    public static JType getOtherAttributesType(JCodeModel model) {
+        return model.ref(Map.class).narrow(QName.class, String.class);
+    }
+
 	public static FieldOutline[] filter(final FieldOutline[] fieldOutlines,
 			final Ignoring ignoring) {
-		return ArrayUtils.filter(fieldOutlines, new Predicate<FieldOutline>() {
-			public boolean evaluate(FieldOutline fieldOutline) {
-				return !ignoring.isIgnored(fieldOutline);
+        return ArrayUtils.filter(fieldOutlines, new Predicate<FieldOutline>() {
+            public boolean evaluate(FieldOutline fieldOutline) {
+                return !ignoring.isIgnored(fieldOutline);
 
-			}
-		}, FieldOutline.class);
+            }
+        }, FieldOutline.class);
 	}
 }

--- a/jaxb-plugins-parent/tests/qa-strategic/src/main/resources/binding.xjb
+++ b/jaxb-plugins-parent/tests/qa-strategic/src/main/resources/binding.xjb
@@ -15,7 +15,7 @@
 
 	<jaxb:bindings schemaLocation="schema.xsd" node="/xs:schema">
 		<jaxb:schemaBindings>
-			<jaxb:package name="org.jvnet.jaxb2_commons.tests.qa.strategic"/>
+			<jaxb:package name="org.jvnet.jaxb.tests.qa.strategic"/>
 		</jaxb:schemaBindings>
 	</jaxb:bindings>
 </jaxb:bindings>

--- a/jaxb-plugins-parent/tests/qa-strategic/src/main/resources/schema.xsd
+++ b/jaxb-plugins-parent/tests/qa-strategic/src/main/resources/schema.xsd
@@ -149,6 +149,9 @@
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:element name="facet" type="facetType"/>
+  <xs:complexType name="complexTypeWithAny">
+    <xs:anyAttribute namespace="##other" processContents="strict"/>
+  </xs:complexType>
 	<xs:complexType name="facetType">
 		<xs:sequence>
 			<xs:element name="singlePattern" minOccurs="0">

--- a/jaxb-plugins-parent/tests/qa-strategic/src/test/java/org/jvnet/jaxb/tests/qa/strategic/ComplexTypeWithAnyTest.java
+++ b/jaxb-plugins-parent/tests/qa-strategic/src/test/java/org/jvnet/jaxb/tests/qa/strategic/ComplexTypeWithAnyTest.java
@@ -1,0 +1,74 @@
+package org.jvnet.jaxb.tests.qa.strategic;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.jvnet.jaxb.lang.ToStringStrategy;
+
+import javax.xml.namespace.QName;
+
+public class ComplexTypeWithAnyTest {
+
+    @Test
+    public void testToString() {
+        ComplexTypeWithAny c1 = new ComplexTypeWithAny();
+        c1.getOtherAttributes().put(new QName("key"), "value");
+
+        String c1ToString = c1.toString();
+        Assertions.assertTrue(c1ToString.startsWith("org.jvnet.jaxb.tests.qa.strategic.ComplexTypeWithAny"));
+        Assertions.assertTrue(c1ToString.contains("otherAttributes={key=value}"));
+    }
+
+    @Test
+    public void testEquals() {
+        ComplexTypeWithAny c1 = new ComplexTypeWithAny();
+        c1.getOtherAttributes().put(new QName("key"), "value");
+
+        ComplexTypeWithAny c2 = new ComplexTypeWithAny();
+        c2.getOtherAttributes().put(new QName("key"), "value");
+
+        Assertions.assertEquals(c1, c2);
+    }
+
+    @Test
+    public void testHashCode() {
+        ComplexTypeWithAny c1 = new ComplexTypeWithAny();
+        c1.getOtherAttributes().put(new QName("key"), "value");
+        ComplexTypeWithAny c2 = new ComplexTypeWithAny();
+        c2.getOtherAttributes().put(new QName("key"), "value2");
+
+        Assertions.assertNotEquals(c1, c2);
+
+        int c1hash = c1.hashCode();
+        int c2hash = c2.hashCode();
+        Assertions.assertNotEquals(c1hash, c2hash);
+    }
+
+    @Test
+    public void testCopyTo() {
+        ComplexTypeWithAny c1 = new ComplexTypeWithAny();
+        c1.getOtherAttributes().put(new QName("key"), "value");
+
+        ComplexTypeWithAny c2 = new ComplexTypeWithAny();
+        c1.copyTo(c2);
+
+        Assertions.assertEquals(c1, c2);
+        Assertions.assertTrue(c2.getOtherAttributes().containsKey(new QName("key")));
+    }
+
+    @Test
+    public void testMerge() {
+        ComplexTypeWithAny c1 = new ComplexTypeWithAny();
+        c1.getOtherAttributes().put(new QName("key1"), "value1");
+        ComplexTypeWithAny c2 = new ComplexTypeWithAny();
+        c2.getOtherAttributes().put(new QName("key2"), "value2");
+
+        ComplexTypeWithAny c3 = new ComplexTypeWithAny();
+        c3.mergeFrom(c1, c2);
+
+        Assertions.assertNotEquals(c1, c3);
+        Assertions.assertNotEquals(c2, c3);
+        Assertions.assertEquals(2, c3.getOtherAttributes().size());
+        Assertions.assertTrue(c3.getOtherAttributes().containsKey(new QName("key1")));
+        Assertions.assertTrue(c3.getOtherAttributes().containsKey(new QName("key2")));
+    }
+}


### PR DESCRIPTION
Fixes #699 

Add support for `otherAttributes` in many plugins :
- Copyable
- Equals
- HashCode
- Mergeable
- ToString
- SimpleEquals
- SimpleHashCode